### PR TITLE
Add arrayContainingOnly and objectContainingOnly

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,62 @@ expect(mock).toBeCalledWith(expect.typeOf("string"));
 
 </td>
 </tr>
+<tr>
+<td>
+
+`arrayContainingOnly`
+
+</td>
+<td>
+
+Checks that value is an array only containing the specified values. Values can be repeated (or omitted), but all elements present should be present in the expected array.
+
+Put another way, it checks that the received array is a subset of (or equal to) the expected array. This is in contrast to `arrayContaining`, which checks that the received array is a superset of (or equal to) the expected array.
+
+</td>
+<td>
+
+```ts
+// will pass
+expect({ array: [1, 2] }).toEqual({
+  array: expect.arrayContainingOnly([1, 2, 3]),
+});
+expect({ array: [1, 2] }).toEqual({
+  array: expect.arrayContainingOnly([1, 2]),
+});
+// will fail
+expect({ array: [1, 2, 3] }).toEqual({
+  array: expect.arrayContainingOnly([1, 2]),
+});
+```
+
+</td>
+</tr>
+<tr>
+<td>
+
+`objectContainingOnly`
+
+</td>
+<td>
+
+Checks that value is an object only containing the specified keys. Keys can be omitted, but all keys present should match the expected object.
+
+Put another way, it checks that the received object is a subset of (or equal to) the expected object. This is in contrast to `objectContaining`, which checks that the received object is a superset of (or equal to) the expected object.
+
+</td>
+<td>
+
+```ts
+// will pass
+expect({ a: 1 }).toEqual(expect.objectContainingOnly({ a: 1, b: 2 }));
+expect({ a: 1, b: 2 }).toEqual(expect.objectContainingOnly({ a: 1, b: 2 }));
+// will fail
+expect({ a: 1, b: 2 }).toEqual(expect.objectContainingOnly({ a: 1 }));
+```
+
+</td>
+</tr>
 </table>
 
 ### Symmetric Matchers

--- a/README.md
+++ b/README.md
@@ -277,6 +277,9 @@ expect({ array: [1, 2] }).toEqual({
 expect({ array: [1, 2] }).toEqual({
   array: expect.arrayContainingOnly([1, 2]),
 });
+expect({ array: [1, 1] }).toEqual({
+  array: expect.arrayContainingOnly([1, 2, 2]),
+});
 // will fail
 expect({ array: [1, 2, 3] }).toEqual({
   array: expect.arrayContainingOnly([1, 2]),

--- a/src/asymmetricMatchers/__snapshots__/array-containing-only.test.ts.snap
+++ b/src/asymmetricMatchers/__snapshots__/array-containing-only.test.ts.snap
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`arrayContainingOnly should expect an array to contain only the expected values 1`] = `
+<d>expect(</b><r>received</g><d>).</b>toEqual<d>(</b><g>expected</g><d>) // deep equality</b>
+
+Expected: <g>arrayContainingOnly<1,2></g>
+Received: <r>[1, 2, 2, 3]</g>
+`;
+
+exports[`arrayContainingOnly should throw an error if the expected value is not an array 1`] = `Expected value must be an array, not number`;
+
+exports[`arrayContainingOnly should throw an error if the received value is not an array 1`] = `
+<d>expect(</b><r>received</g><d>).</b>toEqual<d>(</b><g>expected</g><d>) // deep equality</b>
+
+Expected: <g>arrayContainingOnly<></g>
+Received: <r>1</g>
+`;

--- a/src/asymmetricMatchers/__snapshots__/array-containing-only.test.ts.snap
+++ b/src/asymmetricMatchers/__snapshots__/array-containing-only.test.ts.snap
@@ -7,6 +7,13 @@ Expected: <g>arrayContainingOnly<1,2></g>
 Received: <r>[1, 2, 2, 3]</g>
 `;
 
+exports[`arrayContainingOnly should expect an array to contain only the expected values 2`] = `
+<d>expect(</b><r>received</g><d>).</b>toEqual<d>(</b><g>expected</g><d>) // deep equality</b>
+
+Expected: <g>not.arrayContainingOnly<1,2,3></g>
+Received: <r>[1, 2, 2, 3]</g>
+`;
+
 exports[`arrayContainingOnly should throw an error if the expected value is not an array 1`] = `Expected value must be an array, not number`;
 
 exports[`arrayContainingOnly should throw an error if the received value is not an array 1`] = `

--- a/src/asymmetricMatchers/__snapshots__/array-containing-only.vi.test.ts.snap
+++ b/src/asymmetricMatchers/__snapshots__/array-containing-only.vi.test.ts.snap
@@ -1,0 +1,7 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`arrayContainingOnly > should expect an array to contain only the expected values 1`] = `expected [ 1, 2, 2, 3 ] to deeply equal arrayContainingOnly<1,2>`;
+
+exports[`arrayContainingOnly > should throw an error if the expected value is not an array 1`] = `Expected value must be an array, not number`;
+
+exports[`arrayContainingOnly > should throw an error if the received value is not an array 1`] = `expected 1 to deeply equal arrayContainingOnly<>`;

--- a/src/asymmetricMatchers/__snapshots__/array-containing-only.vi.test.ts.snap
+++ b/src/asymmetricMatchers/__snapshots__/array-containing-only.vi.test.ts.snap
@@ -2,6 +2,8 @@
 
 exports[`arrayContainingOnly > should expect an array to contain only the expected values 1`] = `expected [ 1, 2, 2, 3 ] to deeply equal arrayContainingOnly<1,2>`;
 
+exports[`arrayContainingOnly > should expect an array to contain only the expected values 2`] = `expected [ 1, 2, 2, 3 ] to deeply equal not.arrayContainingOnly<1,2,3>`;
+
 exports[`arrayContainingOnly > should throw an error if the expected value is not an array 1`] = `Expected value must be an array, not number`;
 
 exports[`arrayContainingOnly > should throw an error if the received value is not an array 1`] = `expected 1 to deeply equal arrayContainingOnly<>`;

--- a/src/asymmetricMatchers/__snapshots__/object-containing-only.test.ts.snap
+++ b/src/asymmetricMatchers/__snapshots__/object-containing-only.test.ts.snap
@@ -14,6 +14,13 @@ Expected: <g>objectContainingOnly<[object Object]></g>
 Received: <r>{"a": 1, "b": 2}</g>
 `;
 
+exports[`objectContainingOnly should check if object contains only the expected properties 3`] = `
+<d>expect(</b><r>received</g><d>).</b>toEqual<d>(</b><g>expected</g><d>) // deep equality</b>
+
+Expected: <g>not.objectContainingOnly<[object Object]></g>
+Received: <r>{"a": 1, "b": 2}</g>
+`;
+
 exports[`objectContainingOnly should throw an error if expected value is not an object 1`] = `Expected value must be an object, not number`;
 
 exports[`objectContainingOnly should throw an error if received value is not an object 1`] = `

--- a/src/asymmetricMatchers/__snapshots__/object-containing-only.test.ts.snap
+++ b/src/asymmetricMatchers/__snapshots__/object-containing-only.test.ts.snap
@@ -1,0 +1,24 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`objectContainingOnly should check if object contains only the expected properties 1`] = `
+<d>expect(</b><r>received</g><d>).</b>toEqual<d>(</b><g>expected</g><d>) // deep equality</b>
+
+Expected: <g>objectContainingOnly<[object Object]></g>
+Received: <r>{"a": 1, "b": 2}</g>
+`;
+
+exports[`objectContainingOnly should check if object contains only the expected properties 2`] = `
+<d>expect(</b><r>received</g><d>).</b>toEqual<d>(</b><g>expected</g><d>) // deep equality</b>
+
+Expected: <g>objectContainingOnly<[object Object]></g>
+Received: <r>{"a": 1, "b": 2}</g>
+`;
+
+exports[`objectContainingOnly should throw an error if expected value is not an object 1`] = `Expected value must be an object, not number`;
+
+exports[`objectContainingOnly should throw an error if received value is not an object 1`] = `
+<d>expect(</b><r>received</g><d>).</b>toEqual<d>(</b><g>expected</g><d>) // deep equality</b>
+
+Expected: <g>objectContainingOnly<[object Object]></g>
+Received: <r>1</g>
+`;

--- a/src/asymmetricMatchers/__snapshots__/object-containing-only.vi.test.ts.snap
+++ b/src/asymmetricMatchers/__snapshots__/object-containing-only.vi.test.ts.snap
@@ -4,6 +4,8 @@ exports[`objectContainingOnly > should check if object contains only the expecte
 
 exports[`objectContainingOnly > should check if object contains only the expected properties 2`] = `expected { a: 1, b: 2 } to deeply equal objectContainingOnly<[object Object]>`;
 
+exports[`objectContainingOnly > should check if object contains only the expected properties 3`] = `expected { a: 1, b: 2 } to deeply equal not.objectContainingOnly{…}`;
+
 exports[`objectContainingOnly > should throw an error if expected value is not an object 1`] = `Expected value must be an object, not number`;
 
 exports[`objectContainingOnly > should throw an error if received value is not an object 1`] = `expected 1 to deeply equal objectContainingOnly<[object Object]>`;

--- a/src/asymmetricMatchers/__snapshots__/object-containing-only.vi.test.ts.snap
+++ b/src/asymmetricMatchers/__snapshots__/object-containing-only.vi.test.ts.snap
@@ -1,0 +1,9 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`objectContainingOnly > should check if object contains only the expected properties 1`] = `expected { a: 1, b: 2 } to deeply equal objectContainingOnly<[object Object]>`;
+
+exports[`objectContainingOnly > should check if object contains only the expected properties 2`] = `expected { a: 1, b: 2 } to deeply equal objectContainingOnly<[object Object]>`;
+
+exports[`objectContainingOnly > should throw an error if expected value is not an object 1`] = `Expected value must be an object, not number`;
+
+exports[`objectContainingOnly > should throw an error if received value is not an object 1`] = `expected 1 to deeply equal objectContainingOnly<[object Object]>`;

--- a/src/asymmetricMatchers/__snapshots__/typeof.test.ts.snap
+++ b/src/asymmetricMatchers/__snapshots__/typeof.test.ts.snap
@@ -18,3 +18,22 @@ exports[`typeOf throws if value mismatches 2`] = `
 <r>+   "value": 1,</g>
 <d>  }</b>
 `;
+
+exports[`typeOf throws if value mismatches 3`] = `
+<d>expect(</b><r>received</g><d>).</b>toEqual<d>(</b><g>expected</g><d>) // deep equality</b>
+
+Expected: <g>not.typeOf<number></g>
+Received: <r>1</g>
+`;
+
+exports[`typeOf throws if value mismatches 4`] = `
+<d>expect(</b><r>received</g><d>).</b>toEqual<d>(</b><g>expected</g><d>) // deep equality</b>
+
+<g>- Expected  - 1</g>
+<r>+ Received  + 1</g>
+
+<d>  Object {</b>
+<g>-   "value": not.typeOf<number>,</g>
+<r>+   "value": 1,</g>
+<d>  }</b>
+`;

--- a/src/asymmetricMatchers/__snapshots__/typeof.vi.test.ts.snap
+++ b/src/asymmetricMatchers/__snapshots__/typeof.vi.test.ts.snap
@@ -3,3 +3,7 @@
 exports[`typeOf > throws if value mismatches 1`] = `expected 1 to deeply equal typeOf<string>`;
 
 exports[`typeOf > throws if value mismatches 2`] = `expected { value: 1 } to deeply equal { value: typeOf<string> }`;
+
+exports[`typeOf > throws if value mismatches 3`] = `expected 1 to deeply equal not.typeOf<number>`;
+
+exports[`typeOf > throws if value mismatches 4`] = `expected { value: 1 } to deeply equal { value: not.typeOf<number> }`;

--- a/src/asymmetricMatchers/array-containing-only.test.ts
+++ b/src/asymmetricMatchers/array-containing-only.test.ts
@@ -10,6 +10,12 @@ describe("arrayContainingOnly", () => {
       expect([1, 2, 2, 3]).toEqual(expect.arrayContainingOnly([1, 2]));
     }).toThrowErrorMatchingSnapshot();
 
+    expect([1, 2, 2, 3]).toEqual(expect.not.arrayContainingOnly([1, 2]));
+
+    expect(() => {
+      expect([1, 2, 2, 3]).toEqual(expect.not.arrayContainingOnly([1, 2, 3]));
+    }).toThrowErrorMatchingSnapshot();
+
     // vs
     expect([1, 2, 2, 3]).toEqual(expect.arrayContaining([1, 2]));
   });

--- a/src/asymmetricMatchers/array-containing-only.test.ts
+++ b/src/asymmetricMatchers/array-containing-only.test.ts
@@ -5,9 +5,13 @@ expect.addSnapshotSerializer(alignedAnsiStyleSerializer);
 describe("arrayContainingOnly", () => {
   it("should expect an array to contain only the expected values", () => {
     expect([1, 2, 2, 3]).toEqual(expect.arrayContainingOnly([1, 2, 3]));
+
     expect(() => {
       expect([1, 2, 2, 3]).toEqual(expect.arrayContainingOnly([1, 2]));
     }).toThrowErrorMatchingSnapshot();
+
+    // vs
+    expect([1, 2, 2, 3]).toEqual(expect.arrayContaining([1, 2]));
   });
   it("should throw an error if the expected value is not an array", () => {
     expect(() => {

--- a/src/asymmetricMatchers/array-containing-only.test.ts
+++ b/src/asymmetricMatchers/array-containing-only.test.ts
@@ -1,0 +1,23 @@
+import { alignedAnsiStyleSerializer } from "../utils/tests";
+
+expect.addSnapshotSerializer(alignedAnsiStyleSerializer);
+
+describe("arrayContainingOnly", () => {
+  it("should expect an array to contain only the expected values", () => {
+    expect([1, 2, 2, 3]).toEqual(expect.arrayContainingOnly([1, 2, 3]));
+    expect(() => {
+      expect([1, 2, 2, 3]).toEqual(expect.arrayContainingOnly([1, 2]));
+    }).toThrowErrorMatchingSnapshot();
+  });
+  it("should throw an error if the expected value is not an array", () => {
+    expect(() => {
+      // @ts-expect-error testing invalid input
+      expect([]).toEqual(expect.arrayContainingOnly(1));
+    }).toThrowErrorMatchingSnapshot();
+  });
+  it("should throw an error if the received value is not an array", () => {
+    expect(() => {
+      expect(1).toEqual(expect.arrayContainingOnly([]));
+    }).toThrowErrorMatchingSnapshot();
+  });
+});

--- a/src/asymmetricMatchers/array-containing-only.ts
+++ b/src/asymmetricMatchers/array-containing-only.ts
@@ -2,6 +2,17 @@ import { printExpected, printReceived } from "jest-matcher-utils";
 import { makeEqualValue } from "../utils";
 import type { MatcherFunction } from "../utils/types";
 
+/**
+ * Matches any array that contains only the expected values.
+ * The array may contain as many of each expected value as it likes (or none), but no other values.
+ *
+ * @example
+ * expect([1, 2, 2, 3]).toEqual(expect.arrayContainingOnly([1, 2, 3])); // pass
+ * expect([1, 2, 2, 3]).toEqual(expect.arrayContainingOnly([1, 2])); // fail
+ *
+ * // whereas
+ * expect([1, 2, 2, 3]).toEqual(expect.arrayContaining([1, 2])); // pass
+ */
 export const arrayContainingOnly: MatcherFunction<[expected: Array<unknown>]> =
   function (received, expected) {
     if (!Array.isArray(expected)) {
@@ -30,11 +41,14 @@ declare module "./index" {
      * Use `arrayContainingOnly` to expect an array to contain only the expected values.
      * The array may contain as many of each expected value as it likes (or none), but no other values.
      *
+     * Optionally, you can provide a type for the elements using a generic.
      * @example
-     *
      * expect([1, 2, 2, 3]).toEqual(expect.arrayContainingOnly([1, 2, 3])); // pass
      * expect([1, 2, 2, 3]).toEqual(expect.arrayContainingOnly([1, 2])); // fail
+     *
+     * // whereas
+     * expect([1, 2, 2, 3]).toEqual(expect.arrayContaining([1, 2])); // pass
      */
-    arrayContainingOnly(expected: Array<unknown>): boolean;
+    arrayContainingOnly<E = any>(expected: Array<E>): boolean;
   }
 }

--- a/src/asymmetricMatchers/array-containing-only.ts
+++ b/src/asymmetricMatchers/array-containing-only.ts
@@ -1,0 +1,40 @@
+import { printExpected, printReceived } from "jest-matcher-utils";
+import { makeEqualValue } from "../utils";
+import type { MatcherFunction } from "../utils/types";
+
+export const arrayContainingOnly: MatcherFunction<[expected: Array<unknown>]> =
+  function (received, expected) {
+    if (!Array.isArray(expected)) {
+      throw new Error(
+        `Expected value must be an array, not ${typeof expected}`,
+      );
+    }
+    const equalValue = makeEqualValue(this);
+    const pass =
+      Array.isArray(received) &&
+      received.every((item) =>
+        expected.some((expectedItem) => equalValue(item, expectedItem)),
+      );
+    return {
+      pass,
+      message: () =>
+        pass
+          ? `expected ${printReceived(received)} not to be an array containing only elements from ${printExpected(expected)}`
+          : `expected ${printReceived(received)} to to be an array containing only elements from ${printExpected(expected)}`,
+    };
+  };
+
+declare module "./index" {
+  export interface AsymmetricMixNMatchers {
+    /**
+     * Use `arrayContainingOnly` to expect an array to contain only the expected values.
+     * The array may contain as many of each expected value as it likes (or none), but no other values.
+     *
+     * @example
+     *
+     * expect([1, 2, 2, 3]).toEqual(expect.arrayContainingOnly([1, 2, 3])); // pass
+     * expect([1, 2, 2, 3]).toEqual(expect.arrayContainingOnly([1, 2])); // fail
+     */
+    arrayContainingOnly(expected: Array<unknown>): boolean;
+  }
+}

--- a/src/asymmetricMatchers/array-containing-only.vi.test.ts
+++ b/src/asymmetricMatchers/array-containing-only.vi.test.ts
@@ -1,0 +1,24 @@
+import { expect, it, describe } from "vitest";
+import { alignedAnsiStyleSerializer } from "../utils/tests";
+
+expect.addSnapshotSerializer(alignedAnsiStyleSerializer);
+
+describe("arrayContainingOnly", () => {
+  it("should expect an array to contain only the expected values", () => {
+    expect([1, 2, 2, 3]).toEqual(expect.arrayContainingOnly([1, 2, 3]));
+    expect(() => {
+      expect([1, 2, 2, 3]).toEqual(expect.arrayContainingOnly([1, 2]));
+    }).toThrowErrorMatchingSnapshot();
+  });
+  it("should throw an error if the expected value is not an array", () => {
+    expect(() => {
+      // @ts-expect-error testing invalid input
+      expect([]).toEqual(expect.arrayContainingOnly(1));
+    }).toThrowErrorMatchingSnapshot();
+  });
+  it("should throw an error if the received value is not an array", () => {
+    expect(() => {
+      expect(1).toEqual(expect.arrayContainingOnly([]));
+    }).toThrowErrorMatchingSnapshot();
+  });
+});

--- a/src/asymmetricMatchers/array-containing-only.vi.test.ts
+++ b/src/asymmetricMatchers/array-containing-only.vi.test.ts
@@ -9,6 +9,11 @@ describe("arrayContainingOnly", () => {
     expect(() => {
       expect([1, 2, 2, 3]).toEqual(expect.arrayContainingOnly([1, 2]));
     }).toThrowErrorMatchingSnapshot();
+
+    expect([1, 2, 2, 3]).toEqual(expect.not.arrayContainingOnly([1, 2]));
+    expect(() => {
+      expect([1, 2, 2, 3]).toEqual(expect.not.arrayContainingOnly([1, 2, 3]));
+    }).toThrowErrorMatchingSnapshot();
   });
   it("should throw an error if the expected value is not an array", () => {
     expect(() => {

--- a/src/asymmetricMatchers/index.ts
+++ b/src/asymmetricMatchers/index.ts
@@ -3,4 +3,5 @@ export interface AsymmetricMixNMatchers {}
 
 export { arrayContainingOnly } from "./array-containing-only";
 export { exactly } from "./exactly";
+export { objectContainingOnly } from "./object-containing-only";
 export { typeOf } from "./typeof";

--- a/src/asymmetricMatchers/index.ts
+++ b/src/asymmetricMatchers/index.ts
@@ -1,5 +1,6 @@
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface AsymmetricMixNMatchers {}
 
+export { arrayContainingOnly } from "./array-containing-only";
 export { exactly } from "./exactly";
 export { typeOf } from "./typeof";

--- a/src/asymmetricMatchers/object-containing-only.test.ts
+++ b/src/asymmetricMatchers/object-containing-only.test.ts
@@ -1,0 +1,29 @@
+import { alignedAnsiStyleSerializer } from "../utils/tests";
+
+expect.addSnapshotSerializer(alignedAnsiStyleSerializer);
+
+describe("objectContainingOnly", () => {
+  it("should check if object contains only the expected properties", () => {
+    expect({ a: 1 }).toEqual(expect.objectContainingOnly({ a: 1, b: 2 }));
+
+    expect(() => {
+      expect({ a: 1, b: 2 }).toEqual(expect.objectContainingOnly({ a: 1 }));
+    }).toThrowErrorMatchingSnapshot();
+
+    expect(() => {
+      expect({ a: 1, b: 2 }).toEqual(
+        expect.objectContainingOnly({ a: 1, b: 3 }),
+      );
+    }).toThrowErrorMatchingSnapshot();
+  });
+  it("should throw an error if expected value is not an object", () => {
+    expect(() => {
+      expect({}).toEqual(expect.objectContainingOnly(1));
+    }).toThrowErrorMatchingSnapshot();
+  });
+  it("should throw an error if received value is not an object", () => {
+    expect(() => {
+      expect(1).toEqual(expect.objectContainingOnly({}));
+    }).toThrowErrorMatchingSnapshot();
+  });
+});

--- a/src/asymmetricMatchers/object-containing-only.test.ts
+++ b/src/asymmetricMatchers/object-containing-only.test.ts
@@ -15,6 +15,14 @@ describe("objectContainingOnly", () => {
         expect.objectContainingOnly({ a: 1, b: 3 }),
       );
     }).toThrowErrorMatchingSnapshot();
+
+    expect({ a: 1, b: 2 }).toEqual(expect.not.objectContainingOnly({ a: 1 }));
+
+    expect(() => {
+      expect({ a: 1, b: 2 }).toEqual(
+        expect.not.objectContainingOnly({ a: 1, b: 2 }),
+      );
+    }).toThrowErrorMatchingSnapshot();
   });
   it("should throw an error if expected value is not an object", () => {
     expect(() => {

--- a/src/asymmetricMatchers/object-containing-only.ts
+++ b/src/asymmetricMatchers/object-containing-only.ts
@@ -1,0 +1,94 @@
+import { printReceived } from "jest-matcher-utils";
+import { makeEqualValue } from "../utils";
+import type { MatcherFunction } from "../utils/types";
+
+// Retrieves an object's keys for evaluation by getObjectSubset.  This evaluates
+// the prototype chain for string keys but not for non-enumerable symbols.
+// (Otherwise, it could find values such as a Set or Map's Symbol.toStringTag,
+// with unexpected results.)
+export const getObjectKeys = (object: object): Array<string | symbol> => {
+  return [
+    ...Object.keys(object),
+    ...Object.getOwnPropertySymbols(object).filter(
+      (s) => Object.getOwnPropertyDescriptor(object, s)?.enumerable,
+    ),
+  ];
+};
+
+function getPrototype(obj: object) {
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  if (Object.getPrototypeOf) {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+    return Object.getPrototypeOf(obj);
+  }
+
+  if (obj.constructor.prototype == obj) {
+    return null;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+  return obj.constructor.prototype;
+}
+
+export function hasProperty(
+  obj: object | null,
+  property: string | symbol,
+): boolean {
+  if (!obj) {
+    return false;
+  }
+
+  if (Object.prototype.hasOwnProperty.call(obj, property)) {
+    return true;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+  return hasProperty(getPrototype(obj), property);
+}
+
+export const objectContainingOnly: MatcherFunction<
+  [expected: Record<string | symbol, unknown>]
+> = function (received, expected) {
+  if (typeof expected !== "object") {
+    throw new Error(`Expected value must be an object, not ${typeof expected}`);
+  }
+
+  const receivedIsObject = typeof received === "object" && received !== null;
+  let pass = receivedIsObject;
+
+  if (receivedIsObject) {
+    const equalValue = makeEqualValue(this);
+    const receivedKeys = getObjectKeys(received);
+
+    for (const key of receivedKeys) {
+      if (
+        !hasProperty(expected, key) ||
+        !equalValue(received[key as never], expected[key])
+      ) {
+        pass = false;
+        break;
+      }
+    }
+  }
+
+  return {
+    pass,
+    message: () =>
+      `expected ${printReceived(received)} ${pass ? "not" : ""} to be an object containing only keys from ${printReceived(expected)}`,
+  };
+};
+
+declare module "./index" {
+  interface AsymmetricMixNMatchers {
+    /**
+     * Matches any object containing only matching keys and values.
+     * Not all keys in the expected object need to be present in the received object.
+     *
+     * @example
+     * expect({ a: 1 }).toEqual(objectContainingOnly({ a: 1, b: 2 })); // pass
+     *
+     * expect({ a: 1, b: 2 }).toEqual(objectContainingOnly({ a: 1 })); // fail
+     */
+    objectContainingOnly<E = {}>(expected: E): boolean;
+  }
+}

--- a/src/asymmetricMatchers/object-containing-only.vi.test.ts
+++ b/src/asymmetricMatchers/object-containing-only.vi.test.ts
@@ -16,6 +16,14 @@ describe("objectContainingOnly", () => {
         expect.objectContainingOnly({ a: 1, b: 3 }),
       );
     }).toThrowErrorMatchingSnapshot();
+
+    expect({ a: 1, b: 2 }).toEqual(expect.not.objectContainingOnly({ a: 1 }));
+
+    expect(() => {
+      expect({ a: 1, b: 2 }).toEqual(
+        expect.not.objectContainingOnly({ a: 1, b: 2 }),
+      );
+    }).toThrowErrorMatchingSnapshot();
   });
   it("should throw an error if expected value is not an object", () => {
     expect(() => {

--- a/src/asymmetricMatchers/object-containing-only.vi.test.ts
+++ b/src/asymmetricMatchers/object-containing-only.vi.test.ts
@@ -1,0 +1,30 @@
+import { expect, it, describe } from "vitest";
+import { alignedAnsiStyleSerializer } from "../utils/tests";
+
+expect.addSnapshotSerializer(alignedAnsiStyleSerializer);
+
+describe("objectContainingOnly", () => {
+  it("should check if object contains only the expected properties", () => {
+    expect({ a: 1 }).toEqual(expect.objectContainingOnly({ a: 1, b: 2 }));
+
+    expect(() => {
+      expect({ a: 1, b: 2 }).toEqual(expect.objectContainingOnly({ a: 1 }));
+    }).toThrowErrorMatchingSnapshot();
+
+    expect(() => {
+      expect({ a: 1, b: 2 }).toEqual(
+        expect.objectContainingOnly({ a: 1, b: 3 }),
+      );
+    }).toThrowErrorMatchingSnapshot();
+  });
+  it("should throw an error if expected value is not an object", () => {
+    expect(() => {
+      expect({}).toEqual(expect.objectContainingOnly(1));
+    }).toThrowErrorMatchingSnapshot();
+  });
+  it("should throw an error if received value is not an object", () => {
+    expect(() => {
+      expect(1).toEqual(expect.objectContainingOnly({}));
+    }).toThrowErrorMatchingSnapshot();
+  });
+});

--- a/src/asymmetricMatchers/typeof.test.ts
+++ b/src/asymmetricMatchers/typeof.test.ts
@@ -7,6 +7,10 @@ describe("typeOf", () => {
     expect(1).toEqual(expect.typeOf("number"));
 
     expect({ value: 1 }).toEqual({ value: expect.typeOf("number") });
+
+    expect(1).toEqual(expect.not.typeOf("string"));
+
+    expect({ value: 1 }).toEqual({ value: expect.not.typeOf("string") });
   });
   it("throws if value mismatches", () => {
     expect(() => {
@@ -15,6 +19,14 @@ describe("typeOf", () => {
 
     expect(() => {
       expect({ value: 1 }).toEqual({ value: expect.typeOf("string") });
+    }).toThrowErrorMatchingSnapshot();
+
+    expect(() => {
+      expect(1).toEqual(expect.not.typeOf("number"));
+    }).toThrowErrorMatchingSnapshot();
+
+    expect(() => {
+      expect({ value: 1 }).toEqual({ value: expect.not.typeOf("number") });
     }).toThrowErrorMatchingSnapshot();
   });
 });

--- a/src/asymmetricMatchers/typeof.vi.test.ts
+++ b/src/asymmetricMatchers/typeof.vi.test.ts
@@ -9,6 +9,10 @@ describe("typeOf", () => {
     expect(1).toEqual(expect.typeOf("number"));
 
     expect({ value: 1 }).toEqual({ value: expect.typeOf("number") });
+
+    expect(1).toEqual(expect.not.typeOf("string"));
+
+    expect({ value: 1 }).toEqual({ value: expect.not.typeOf("string") });
   });
   it("throws if value mismatches", () => {
     expect(() => {
@@ -17,6 +21,14 @@ describe("typeOf", () => {
 
     expect(() => {
       expect({ value: 1 }).toEqual({ value: expect.typeOf("string") });
+    }).toThrowErrorMatchingSnapshot();
+
+    expect(() => {
+      expect(1).toEqual(expect.not.typeOf("number"));
+    }).toThrowErrorMatchingSnapshot();
+
+    expect(() => {
+      expect({ value: 1 }).toEqual({ value: expect.not.typeOf("number") });
     }).toThrowErrorMatchingSnapshot();
   });
 });


### PR DESCRIPTION
```ts
// will pass
expect({ array: [1, 2] }).toEqual({
  array: expect.arrayContainingOnly([1, 2, 3]),
});
expect({ array: [1, 2] }).toEqual({
  array: expect.arrayContainingOnly([1, 2]),
});
// will fail
expect({ array: [1, 2, 3] }).toEqual({
  array: expect.arrayContainingOnly([1, 2]),
});


// will pass
expect({ a: 1 }).toEqual(expect.objectContainingOnly({ a: 1, b: 2 }));
expect({ a: 1, b: 2 }).toEqual(expect.objectContainingOnly({ a: 1, b: 2 }));
// will fail
expect({ a: 1, b: 2 }).toEqual(expect.objectContainingOnly({ a: 1 }));
```