### PR TITLE
Add iterableOf and recordOf matchers

### DIFF
--- a/README.md
+++ b/README.md
@@ -485,6 +485,10 @@ expect({
 
 Matches an object where every value matches the expected value, using deep equality.
 
+Optionally, you can pass two arguments and the first will be matched against keys.
+
+_Note: keys and values are retrieved using `Object.entries`, so only string (non-symbol) enumerable keys are checked._
+
 </td>
 <td>
 
@@ -493,6 +497,12 @@ expect({
   object: { a: 1, b: 2 },
 }).toEqual({
   object: expect.recordOf(expect.any(Number)),
+});
+
+expect({
+  object: { a: 1, b: 2 },
+}).toEqual({
+  object: expect.recordOf(expect.any(String), expect.any(Number)),
 });
 ```
 
@@ -508,6 +518,10 @@ expect({
 
 Matches an object where every value matches the expected value, using [strict deep equality](https://jestjs.io/docs/expect#tostrictequalvalue).
 
+Optionally, you can pass two arguments and the first will be matched against keys.
+
+_Note: keys and values are retrieved using `Object.entries`, so only string (non-symbol) enumerable keys are checked._
+
 </td>
 <td>
 
@@ -516,6 +530,12 @@ expect({
   object: { a: 1, b: 2 },
 }).toEqual({
   object: expect.strictRecordOf(expect.any(Number)),
+});
+
+expect({
+  object: { a: 1, b: 2 },
+}).toEqual({
+  object: expect.strictRecordOf(expect.any(String), expect.any(Number)),
 });
 ```
 
@@ -659,11 +679,16 @@ expect([1, 2, 3]).toBeStrictIterableOf(expect.any(Number));
 
 Assert a value is an object where every value matches the expected value, using deep equality.
 
+Optionally, you can pass two arguments and the first will be matched against keys.
+
+_Note: keys and values are retrieved using `Object.entries`, so only string (non-symbol) enumerable keys are checked._
+
 </td>
 <td>
 
 ```ts
 expect({ a: 1, b: 2 }).toBeRecordOf(expect.any(Number));
+expect({ a: 1, b: 2 }).toBeRecordOf(expect.any(String), expect.any(Number));
 ```
 
 </td>
@@ -679,11 +704,19 @@ expect({ a: 1, b: 2 }).toBeRecordOf(expect.any(Number));
 
 Assert a value is an object where every value matches the expected value, using [strict deep equality](https://jestjs.io/docs/expect#tostrictequalvalue).
 
+Optionally, you can pass two arguments and the first will be matched against keys.
+
+_Note: keys and values are retrieved using `Object.entries`, so only string (non-symbol) enumerable keys are checked._
+
 </td>
 <td>
 
 ```ts
 expect({ a: 1, b: 2 }).toBeStrictRecordOf(expect.any(Number));
+expect({ a: 1, b: 2 }).toBeStrictRecordOf(
+  expect.any(String),
+  expect.any(Number),
+);
 ```
 
 </td>

--- a/README.md
+++ b/README.md
@@ -429,6 +429,98 @@ expect({
 
 </td>
 </tr>
+<tr>
+<td>
+
+`iterableOf`
+
+</td>
+<td>
+
+Matches an iterable where every value matches the expected value, using deep equality.
+
+</td>
+<td>
+
+```ts
+expect({
+  array: [1, 2, 3],
+}).toEqual({
+  array: expect.iterableOf(expect.any(Number)),
+});
+```
+
+</td>
+</tr>
+<tr>
+<td>
+
+`strictIterableOf`
+
+</td>
+<td>
+
+Matches an iterable where every value matches the expected value, using [strict deep equality](https://jestjs.io/docs/expect#tostrictequalvalue).
+
+</td>
+<td>
+
+```ts
+expect({
+  array: [1, 2, 3],
+}).toEqual({
+  array: expect.strictIterableOf(expect.any(Number)),
+});
+```
+
+</td>
+</tr>
+<tr>
+<td>
+
+`recordOf`
+
+</td>
+<td>
+
+Matches an object where every value matches the expected value, using deep equality.
+
+</td>
+<td>
+
+```ts
+expect({
+  object: { a: 1, b: 2 },
+}).toEqual({
+  object: expect.recordOf(expect.any(Number)),
+});
+```
+
+</td>
+</tr>
+<tr>
+<td>
+
+`strictRecordOf`
+
+</td>
+<td>
+
+Matches an object where every value matches the expected value, using [strict deep equality](https://jestjs.io/docs/expect#tostrictequalvalue).
+
+</td>
+<td>
+
+```ts
+expect({
+  object: { a: 1, b: 2 },
+}).toEqual({
+  object: expect.strictRecordOf(expect.any(Number)),
+});
+```
+
+</td>
+</tr>
 </table>
 
 ### Symmetric Matchers
@@ -514,6 +606,84 @@ Assert a value is an iterable that satisfies the specified sequence of values, u
 
 ```ts
 expect([1, 2, 3]).toStrictEqualSequence(1, 2, 3);
+```
+
+</td>
+</tr>
+<tr>
+<td>
+
+`toBeIterableOf`
+
+</td>
+<td>
+
+Assert a value is an iterable where every value matches the expected value, using deep equality.
+
+</td>
+<td>
+
+```ts
+expect([1, 2, 3]).toBeIterableOf(expect.any(Number));
+```
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`tobeStrictIterableOf`
+
+</td>
+<td>
+
+Assert a value is an iterable where every value matches the expected value, using [strict deep equality](https://jestjs.io/docs/expect#tostrictequalvalue).
+
+</td>
+<td>
+
+```ts
+expect([1, 2, 3]).toBeStrictIterableOf(expect.any(Number));
+```
+
+</td>
+</tr>
+<tr>
+<td>
+
+`toBeRecordOf`
+
+</td>
+<td>
+
+Assert a value is an object where every value matches the expected value, using deep equality.
+
+</td>
+<td>
+
+```ts
+expect({ a: 1, b: 2 }).toBeRecordOf(expect.any(Number));
+```
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`toBeStrictRecordOf`
+
+</td>
+<td>
+
+Assert a value is an object where every value matches the expected value, using [strict deep equality](https://jestjs.io/docs/expect#tostrictequalvalue).
+
+</td>
+<td>
+
+```ts
+expect({ a: 1, b: 2 }).toBeStrictRecordOf(expect.any(Number));
 ```
 
 </td>

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "vitest"
   ],
   "scripts": {
+    "clean": "rimraf dist",
     "prepare": "husky install",
     "prebuild": "yarn run type",
     "build": "tsup",
@@ -83,6 +84,7 @@
     "lint-staged": "^15.0.0",
     "prettier": "^3.0.3",
     "publint": "^0.2.2",
+    "rimraf": "^5.0.5",
     "ts-jest": "^29.1.1",
     "ts-node": "^10.9.2",
     "tsup": "^8.0.0",

--- a/src/asymmetricMatchers/index.ts
+++ b/src/asymmetricMatchers/index.ts
@@ -9,3 +9,9 @@ export { typeOf } from "./typeof";
 
 export { ofEnum } from "../shared/enum";
 export { sequence, sequenceOf, strictSequenceOf } from "../shared/sequence";
+export {
+  iterableOf,
+  strictIterableOf,
+  recordOf,
+  strictRecordOf,
+} from "../shared/iterable-of";

--- a/src/matchers/index.ts
+++ b/src/matchers/index.ts
@@ -15,5 +15,10 @@ export {
   toEqualSequence,
   toStrictEqualSequence,
 } from "../shared/sequence";
-
 export { toBeEnum } from "../shared/enum";
+export {
+  toBeIterableOf,
+  toBeStrictIterableOf,
+  toBeRecordOf,
+  toBeStrictRecordOf,
+} from "../shared/iterable-of";

--- a/src/shared/__snapshots__/iterable-of.test.ts.snap
+++ b/src/shared/__snapshots__/iterable-of.test.ts.snap
@@ -42,6 +42,20 @@ Expected: <g>not.recordOf<Any></g>
 Received: <r>{"a": 1, "b": 2, "c": 3}</g>
 `;
 
+exports[`recordOf should match against keys 1`] = `
+<d>expect(</b><r>received</g><d>).</b>toEqual<d>(</b><g>expected</g><d>) // deep equality</b>
+
+Expected: <g>not.recordOf<oneOf, Any></g>
+Received: <r>{"a": 1, "b": 2, "c": 3}</g>
+`;
+
+exports[`recordOf should match against keys 2`] = `
+<d>expect(</b><r>received</g><d>).</b>toEqual<d>(</b><g>expected</g><d>) // deep equality</b>
+
+Expected: <g>recordOf<oneOf, Any></g>
+Received: <r>{"a": 1, "b": 2, "c": 3}</g>
+`;
+
 exports[`recordOf should not match a non-record 1`] = `
 <d>expect(</b><r>received</g><d>).</b>toEqual<d>(</b><g>expected</g><d>) // deep equality</b>
 
@@ -119,6 +133,20 @@ Expected: <g>strictRecordOf<[object Object]></g>
 Received: <r>{"a": {"a": 1}, "b": {"a": 2}}</g>
 `;
 
+exports[`strictRecordOf should match against keys 1`] = `
+<d>expect(</b><r>received</g><d>).</b>toEqual<d>(</b><g>expected</g><d>) // deep equality</b>
+
+Expected: <g>not.strictRecordOf<oneOf, [object Object]></g>
+Received: <r>{"a": {"a": 1}, "b": {"a": 2}}</g>
+`;
+
+exports[`strictRecordOf should match against keys 2`] = `
+<d>expect(</b><r>received</g><d>).</b>toEqual<d>(</b><g>expected</g><d>) // deep equality</b>
+
+Expected: <g>strictRecordOf<oneOf, [object Object]></g>
+Received: <r>{"a": {"a": 1}, "b": {"a": 2}}</g>
+`;
+
 exports[`strictRecordOf should not match a non-record 1`] = `
 <d>expect(</b><r>received</g><d>).</b>toEqual<d>(</b><g>expected</g><d>) // deep equality</b>
 
@@ -163,6 +191,18 @@ exports[`toBeRecordOf should match a record that contains only the expected valu
 <d>expect(</b><r>received</g><d>).</b>not<d>.</b>toBeRecordOf<d>(</b><g>expected</g><d>)</b>
 
 Expected <r>{"a": 1, "b": 2, "c": 3}</g> not to contain only values matching <g>Any<Number></g>
+`;
+
+exports[`toBeRecordOf should match against keys 1`] = `
+<d>expect(</b><r>received</g><d>).</b>not<d>.</b>toBeRecordOf<d>(</b><g>expected</g><d>)</b>
+
+Expected <r>{"a": 1, "b": 2, "c": 3}</g> not to contain only values matching <g>Any<Number></g>
+`;
+
+exports[`toBeRecordOf should match against keys 2`] = `
+<d>expect(</b><r>received</g><d>).</b>toBeRecordOf<d>(</b><g>expected</g><d>)</b>
+
+Expected <r>{"a": 1, "b": 2, "c": 3}</g> to contain only keys matching <g>oneOf<a,b></g>, but found key <r>"c"</g>
 `;
 
 exports[`toBeRecordOf should not match a non-record 1`] = `Expected <r>1</g> to be an object, but it was <r>"number"</g>`;
@@ -221,6 +261,18 @@ exports[`toBeStrictRecordOf should match a record that contains only the expecte
 <d>expect(</b><r>received</g><d>).</b>toBeStrictRecordOf<d>(</b><g>expected</g><d>)</b>
 
 Expected <r>{"a": {"a": 1}, "b": {"a": 2}}</g> to contain only values matching <g>{"a": Any<Number>, "b": undefined}</g>, but item at key a was <r>{"a": 1}</g>
+`;
+
+exports[`toBeStrictRecordOf should match against keys 1`] = `
+<d>expect(</b><r>received</g><d>).</b>not<d>.</b>toBeStrictRecordOf<d>(</b><g>expected</g><d>)</b>
+
+Expected <r>{"a": {"a": 1}, "b": {"a": 2}}</g> not to contain only values matching <g>{"a": Any<Number>}</g>
+`;
+
+exports[`toBeStrictRecordOf should match against keys 2`] = `
+<d>expect(</b><r>received</g><d>).</b>toBeStrictRecordOf<d>(</b><g>expected</g><d>)</b>
+
+Expected <r>{"a": {"a": 1}, "b": {"a": 2}}</g> to contain only keys matching <g>oneOf<a></g>, but found key <r>"b"</g>
 `;
 
 exports[`toBeStrictRecordOf should not match a non-record 1`] = `Expected <r>1</g> to be an object, but it was <r>"number"</g>`;

--- a/src/shared/__snapshots__/iterable-of.test.ts.snap
+++ b/src/shared/__snapshots__/iterable-of.test.ts.snap
@@ -1,0 +1,232 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`iterableOf should match an iterable 1`] = `
+<d>expect(</b><r>received</g><d>).</b>toEqual<d>(</b><g>expected</g><d>) // deep equality</b>
+
+Expected: <g>not.iterableOf<Any></g>
+Received: <r>[1, 2, 3]</g>
+`;
+
+exports[`iterableOf should match an iterable 2`] = `
+<d>expect(</b><r>received</g><d>).</b>toEqual<d>(</b><g>expected</g><d>) // deep equality</b>
+
+Expected: <g>not.iterableOf<Any></g>
+Received: <r>Set {1, 2, 3}</g>
+`;
+
+exports[`iterableOf should not match a non-iterable 1`] = `
+<d>expect(</b><r>received</g><d>).</b>toEqual<d>(</b><g>expected</g><d>) // deep equality</b>
+
+Expected: <g>iterableOf<1></g>
+Received: <r>1</g>
+`;
+
+exports[`iterableOf should not match an iterable that contains a different value 1`] = `
+<d>expect(</b><r>received</g><d>).</b>toEqual<d>(</b><g>expected</g><d>) // deep equality</b>
+
+Expected: <g>iterableOf<Any></g>
+Received: <r>[1, 2, 3]</g>
+`;
+
+exports[`iterableOf should not match an iterable that contains a different value 2`] = `
+<d>expect(</b><r>received</g><d>).</b>toEqual<d>(</b><g>expected</g><d>) // deep equality</b>
+
+Expected: <g>iterableOf<Any></g>
+Received: <r>Set {1, 2, 3}</g>
+`;
+
+exports[`recordOf should match a record 1`] = `
+<d>expect(</b><r>received</g><d>).</b>toEqual<d>(</b><g>expected</g><d>) // deep equality</b>
+
+Expected: <g>not.recordOf<Any></g>
+Received: <r>{"a": 1, "b": 2, "c": 3}</g>
+`;
+
+exports[`recordOf should not match a non-record 1`] = `
+<d>expect(</b><r>received</g><d>).</b>toEqual<d>(</b><g>expected</g><d>) // deep equality</b>
+
+Expected: <g>recordOf<1></g>
+Received: <r>1</g>
+`;
+
+exports[`recordOf should not match a record that contains a different value 1`] = `
+<d>expect(</b><r>received</g><d>).</b>toEqual<d>(</b><g>expected</g><d>) // deep equality</b>
+
+Expected: <g>recordOf<Any></g>
+Received: <r>{"a": 1, "b": 2, "c": 3}</g>
+`;
+
+exports[`strictIterableOf should match an iterable 1`] = `
+<d>expect(</b><r>received</g><d>).</b>toEqual<d>(</b><g>expected</g><d>) // deep equality</b>
+
+Expected: <g>not.strictIterableOf<[object Object]></g>
+Received: <r>[{"a": 1}, {"a": 2}, {"a": 3}]</g>
+`;
+
+exports[`strictIterableOf should match an iterable 2`] = `
+<d>expect(</b><r>received</g><d>).</b>toEqual<d>(</b><g>expected</g><d>) // deep equality</b>
+
+Expected: <g>strictIterableOf<[object Object]></g>
+Received: <r>[{"a": 1}, {"a": 2}, {"a": 3}]</g>
+`;
+
+exports[`strictIterableOf should match an iterable 3`] = `
+<d>expect(</b><r>received</g><d>).</b>toEqual<d>(</b><g>expected</g><d>) // deep equality</b>
+
+Expected: <g>not.strictIterableOf<[object Object]></g>
+Received: <r>Set {{"a": 1}, {"a": 2}, {"a": 3}}</g>
+`;
+
+exports[`strictIterableOf should match an iterable 4`] = `
+<d>expect(</b><r>received</g><d>).</b>toEqual<d>(</b><g>expected</g><d>) // deep equality</b>
+
+Expected: <g>strictIterableOf<[object Object]></g>
+Received: <r>Set {{"a": 1}, {"a": 2}, {"a": 3}}</g>
+`;
+
+exports[`strictIterableOf should not match a non-iterable 1`] = `
+<d>expect(</b><r>received</g><d>).</b>toEqual<d>(</b><g>expected</g><d>) // deep equality</b>
+
+Expected: <g>strictIterableOf<1></g>
+Received: <r>1</g>
+`;
+
+exports[`strictIterableOf should not match an iterable that contains a different value 1`] = `
+<d>expect(</b><r>received</g><d>).</b>toEqual<d>(</b><g>expected</g><d>) // deep equality</b>
+
+Expected: <g>strictIterableOf<[object Object]></g>
+Received: <r>[{"a": 1}, {"a": 2}, {"a": 3}]</g>
+`;
+
+exports[`strictIterableOf should not match an iterable that contains a different value 2`] = `
+<d>expect(</b><r>received</g><d>).</b>toEqual<d>(</b><g>expected</g><d>) // deep equality</b>
+
+Expected: <g>strictIterableOf<[object Object]></g>
+Received: <r>Set {{"a": 1}, {"a": 2}, {"a": 3}}</g>
+`;
+
+exports[`strictRecordOf should match a record 1`] = `
+<d>expect(</b><r>received</g><d>).</b>toEqual<d>(</b><g>expected</g><d>) // deep equality</b>
+
+Expected: <g>not.strictRecordOf<[object Object]></g>
+Received: <r>{"a": {"a": 1}, "b": {"a": 2}}</g>
+`;
+
+exports[`strictRecordOf should match a record 2`] = `
+<d>expect(</b><r>received</g><d>).</b>toEqual<d>(</b><g>expected</g><d>) // deep equality</b>
+
+Expected: <g>strictRecordOf<[object Object]></g>
+Received: <r>{"a": {"a": 1}, "b": {"a": 2}}</g>
+`;
+
+exports[`strictRecordOf should not match a non-record 1`] = `
+<d>expect(</b><r>received</g><d>).</b>toEqual<d>(</b><g>expected</g><d>) // deep equality</b>
+
+Expected: <g>strictRecordOf<1></g>
+Received: <r>1</g>
+`;
+
+exports[`strictRecordOf should not match a record that contains a different value 1`] = `
+<d>expect(</b><r>received</g><d>).</b>toEqual<d>(</b><g>expected</g><d>) // deep equality</b>
+
+Expected: <g>strictRecordOf<[object Object]></g>
+Received: <r>{"a": {"a": 1}, "b": {"a": 2}}</g>
+`;
+
+exports[`toBeIterableOf should match an iterable that contains only the expected values 1`] = `
+<d>expect(</b><r>received</g><d>).</b>not<d>.</b>toBeIterableOf<d>(</b><g>expected</g><d>)</b>
+
+Expected <r>[1, 2, 3]</g> not to contain only <g>Any<Number></g> values
+`;
+
+exports[`toBeIterableOf should match an iterable that contains only the expected values 2`] = `
+<d>expect(</b><r>received</g><d>).</b>not<d>.</b>toBeIterableOf<d>(</b><g>expected</g><d>)</b>
+
+Expected <r>Set {1, 2, 3}</g> not to contain only <g>Any<Number></g> values
+`;
+
+exports[`toBeIterableOf should not match a non-iterable 1`] = `Expected <r>1</g> to be an iterable`;
+
+exports[`toBeIterableOf should not match an iterable that contains a different value 1`] = `
+<d>expect(</b><r>received</g><d>).</b>toBeIterableOf<d>(</b><g>expected</g><d>)</b>
+
+Expected <r>[1, 2, 3]</g> to contain only <g>Any<String></g> values, but item at index 0 was <r>1</g>
+`;
+
+exports[`toBeIterableOf should not match an iterable that contains a different value 2`] = `
+<d>expect(</b><r>received</g><d>).</b>toBeIterableOf<d>(</b><g>expected</g><d>)</b>
+
+Expected <r>Set {1, 2, 3}</g> to contain only <g>Any<String></g> values, but item at index 0 was <r>1</g>
+`;
+
+exports[`toBeRecordOf should match a record that contains only the expected values 1`] = `
+<d>expect(</b><r>received</g><d>).</b>not<d>.</b>toBeRecordOf<d>(</b><g>expected</g><d>)</b>
+
+Expected <r>{"a": 1, "b": 2, "c": 3}</g> not to contain only <g>Any<Number></g> values
+`;
+
+exports[`toBeRecordOf should not match a non-record 1`] = `Expected <r>1</g> to be an object, but it was <r>"number"</g>`;
+
+exports[`toBeRecordOf should not match a record that contains a different value 1`] = `
+<d>expect(</b><r>received</g><d>).</b>toBeRecordOf<d>(</b><g>expected</g><d>)</b>
+
+Expected <r>{"a": 1, "b": 2, "c": 3}</g> to contain only <g>Any<String></g> values, but item at key a was <r>1</g>
+`;
+
+exports[`toBeStrictIterableOf should match an iterable that contains only the expected values 1`] = `
+<d>expect(</b><r>received</g><d>).</b>not<d>.</b>toBeStrictIterableOf<d>(</b><g>expected</g><d>)</b>
+
+Expected <r>[{"a": 1}, {"a": 2}, {"a": 3}]</g> not to contain only <g>{"a": Any<Number>}</g> values
+`;
+
+exports[`toBeStrictIterableOf should match an iterable that contains only the expected values 2`] = `
+<d>expect(</b><r>received</g><d>).</b>toBeStrictIterableOf<d>(</b><g>expected</g><d>)</b>
+
+Expected <r>[{"a": 1}, {"a": 2}, {"a": 3}]</g> to contain only <g>{"a": Any<Number>, "b": undefined}</g> values, but item at index 0 was <r>{"a": 1}</g>
+`;
+
+exports[`toBeStrictIterableOf should match an iterable that contains only the expected values 3`] = `
+<d>expect(</b><r>received</g><d>).</b>not<d>.</b>toBeStrictIterableOf<d>(</b><g>expected</g><d>)</b>
+
+Expected <r>Set {{"a": 1}, {"a": 2}, {"a": 3}}</g> not to contain only <g>{"a": Any<Number>}</g> values
+`;
+
+exports[`toBeStrictIterableOf should match an iterable that contains only the expected values 4`] = `
+<d>expect(</b><r>received</g><d>).</b>toBeStrictIterableOf<d>(</b><g>expected</g><d>)</b>
+
+Expected <r>Set {{"a": 1}, {"a": 2}, {"a": 3}}</g> to contain only <g>{"a": Any<Number>, "b": undefined}</g> values, but item at index 0 was <r>{"a": 1}</g>
+`;
+
+exports[`toBeStrictIterableOf should not match a non-iterable 1`] = `Expected <r>1</g> to be an iterable`;
+
+exports[`toBeStrictIterableOf should not match an iterable that contains a different value 1`] = `
+<d>expect(</b><r>received</g><d>).</b>toBeStrictIterableOf<d>(</b><g>expected</g><d>)</b>
+
+Expected <r>[{"a": 1}, {"a": 2}, {"a": 3}]</g> to contain only <g>{"a": Any<String>}</g> values, but item at index 0 was <r>{"a": 1}</g>
+`;
+
+exports[`toBeStrictIterableOf should not match an iterable that contains a different value 2`] = `
+<d>expect(</b><r>received</g><d>).</b>toBeStrictIterableOf<d>(</b><g>expected</g><d>)</b>
+
+Expected <r>Set {{"a": 1}, {"a": 2}, {"a": 3}}</g> to contain only <g>{"a": Any<String>}</g> values, but item at index 0 was <r>{"a": 1}</g>
+`;
+
+exports[`toBeStrictRecordOf should match a record that contains only the expected values 1`] = `
+<d>expect(</b><r>received</g><d>).</b>not<d>.</b>toBeStrictRecordOf<d>(</b><g>expected</g><d>)</b>
+
+Expected <r>{"a": {"a": 1}, "b": {"a": 2}}</g> not to contain only <g>{"a": Any<Number>}</g> values
+`;
+
+exports[`toBeStrictRecordOf should match a record that contains only the expected values 2`] = `
+<d>expect(</b><r>received</g><d>).</b>toBeStrictRecordOf<d>(</b><g>expected</g><d>)</b>
+
+Expected <r>{"a": {"a": 1}, "b": {"a": 2}}</g> to contain only <g>{"a": Any<Number>, "b": undefined}</g> values, but item at key a was <r>{"a": 1}</g>
+`;
+
+exports[`toBeStrictRecordOf should not match a non-record 1`] = `Expected <r>1</g> to be an object, but it was <r>"number"</g>`;
+
+exports[`toBeStrictRecordOf should not match a record that contains a different value 1`] = `
+<d>expect(</b><r>received</g><d>).</b>toBeStrictRecordOf<d>(</b><g>expected</g><d>)</b>
+
+Expected <r>{"a": {"a": 1}, "b": {"a": 2}}</g> to contain only <g>{"a": Any<String>}</g> values, but item at key a was <r>{"a": 1}</g>
+`;

--- a/src/shared/__snapshots__/iterable-of.test.ts.snap
+++ b/src/shared/__snapshots__/iterable-of.test.ts.snap
@@ -136,13 +136,13 @@ Received: <r>{"a": {"a": 1}, "b": {"a": 2}}</g>
 exports[`toBeIterableOf should match an iterable that contains only the expected values 1`] = `
 <d>expect(</b><r>received</g><d>).</b>not<d>.</b>toBeIterableOf<d>(</b><g>expected</g><d>)</b>
 
-Expected <r>[1, 2, 3]</g> not to contain only <g>Any<Number></g> values
+Expected <r>[1, 2, 3]</g> not to contain only values matching <g>Any<Number></g>
 `;
 
 exports[`toBeIterableOf should match an iterable that contains only the expected values 2`] = `
 <d>expect(</b><r>received</g><d>).</b>not<d>.</b>toBeIterableOf<d>(</b><g>expected</g><d>)</b>
 
-Expected <r>Set {1, 2, 3}</g> not to contain only <g>Any<Number></g> values
+Expected <r>Set {1, 2, 3}</g> not to contain only values matching <g>Any<Number></g>
 `;
 
 exports[`toBeIterableOf should not match a non-iterable 1`] = `Expected <r>1</g> to be an iterable`;
@@ -150,19 +150,19 @@ exports[`toBeIterableOf should not match a non-iterable 1`] = `Expected <r>1</g>
 exports[`toBeIterableOf should not match an iterable that contains a different value 1`] = `
 <d>expect(</b><r>received</g><d>).</b>toBeIterableOf<d>(</b><g>expected</g><d>)</b>
 
-Expected <r>[1, 2, 3]</g> to contain only <g>Any<String></g> values, but item at index 0 was <r>1</g>
+Expected <r>[1, 2, 3]</g> to contain only values matching <g>Any<String></g>, but item at index 0 was <r>1</g>
 `;
 
 exports[`toBeIterableOf should not match an iterable that contains a different value 2`] = `
 <d>expect(</b><r>received</g><d>).</b>toBeIterableOf<d>(</b><g>expected</g><d>)</b>
 
-Expected <r>Set {1, 2, 3}</g> to contain only <g>Any<String></g> values, but item at index 0 was <r>1</g>
+Expected <r>Set {1, 2, 3}</g> to contain only values matching <g>Any<String></g>, but item at index 0 was <r>1</g>
 `;
 
 exports[`toBeRecordOf should match a record that contains only the expected values 1`] = `
 <d>expect(</b><r>received</g><d>).</b>not<d>.</b>toBeRecordOf<d>(</b><g>expected</g><d>)</b>
 
-Expected <r>{"a": 1, "b": 2, "c": 3}</g> not to contain only <g>Any<Number></g> values
+Expected <r>{"a": 1, "b": 2, "c": 3}</g> not to contain only values matching <g>Any<Number></g>
 `;
 
 exports[`toBeRecordOf should not match a non-record 1`] = `Expected <r>1</g> to be an object, but it was <r>"number"</g>`;
@@ -170,31 +170,31 @@ exports[`toBeRecordOf should not match a non-record 1`] = `Expected <r>1</g> to 
 exports[`toBeRecordOf should not match a record that contains a different value 1`] = `
 <d>expect(</b><r>received</g><d>).</b>toBeRecordOf<d>(</b><g>expected</g><d>)</b>
 
-Expected <r>{"a": 1, "b": 2, "c": 3}</g> to contain only <g>Any<String></g> values, but item at key a was <r>1</g>
+Expected <r>{"a": 1, "b": 2, "c": 3}</g> to contain only values matching <g>Any<String></g>, but item at key a was <r>1</g>
 `;
 
 exports[`toBeStrictIterableOf should match an iterable that contains only the expected values 1`] = `
 <d>expect(</b><r>received</g><d>).</b>not<d>.</b>toBeStrictIterableOf<d>(</b><g>expected</g><d>)</b>
 
-Expected <r>[{"a": 1}, {"a": 2}, {"a": 3}]</g> not to contain only <g>{"a": Any<Number>}</g> values
+Expected <r>[{"a": 1}, {"a": 2}, {"a": 3}]</g> not to contain only values matching <g>{"a": Any<Number>}</g>
 `;
 
 exports[`toBeStrictIterableOf should match an iterable that contains only the expected values 2`] = `
 <d>expect(</b><r>received</g><d>).</b>toBeStrictIterableOf<d>(</b><g>expected</g><d>)</b>
 
-Expected <r>[{"a": 1}, {"a": 2}, {"a": 3}]</g> to contain only <g>{"a": Any<Number>, "b": undefined}</g> values, but item at index 0 was <r>{"a": 1}</g>
+Expected <r>[{"a": 1}, {"a": 2}, {"a": 3}]</g> to contain only values matching <g>{"a": Any<Number>, "b": undefined}</g>, but item at index 0 was <r>{"a": 1}</g>
 `;
 
 exports[`toBeStrictIterableOf should match an iterable that contains only the expected values 3`] = `
 <d>expect(</b><r>received</g><d>).</b>not<d>.</b>toBeStrictIterableOf<d>(</b><g>expected</g><d>)</b>
 
-Expected <r>Set {{"a": 1}, {"a": 2}, {"a": 3}}</g> not to contain only <g>{"a": Any<Number>}</g> values
+Expected <r>Set {{"a": 1}, {"a": 2}, {"a": 3}}</g> not to contain only values matching <g>{"a": Any<Number>}</g>
 `;
 
 exports[`toBeStrictIterableOf should match an iterable that contains only the expected values 4`] = `
 <d>expect(</b><r>received</g><d>).</b>toBeStrictIterableOf<d>(</b><g>expected</g><d>)</b>
 
-Expected <r>Set {{"a": 1}, {"a": 2}, {"a": 3}}</g> to contain only <g>{"a": Any<Number>, "b": undefined}</g> values, but item at index 0 was <r>{"a": 1}</g>
+Expected <r>Set {{"a": 1}, {"a": 2}, {"a": 3}}</g> to contain only values matching <g>{"a": Any<Number>, "b": undefined}</g>, but item at index 0 was <r>{"a": 1}</g>
 `;
 
 exports[`toBeStrictIterableOf should not match a non-iterable 1`] = `Expected <r>1</g> to be an iterable`;
@@ -202,25 +202,25 @@ exports[`toBeStrictIterableOf should not match a non-iterable 1`] = `Expected <r
 exports[`toBeStrictIterableOf should not match an iterable that contains a different value 1`] = `
 <d>expect(</b><r>received</g><d>).</b>toBeStrictIterableOf<d>(</b><g>expected</g><d>)</b>
 
-Expected <r>[{"a": 1}, {"a": 2}, {"a": 3}]</g> to contain only <g>{"a": Any<String>}</g> values, but item at index 0 was <r>{"a": 1}</g>
+Expected <r>[{"a": 1}, {"a": 2}, {"a": 3}]</g> to contain only values matching <g>{"a": Any<String>}</g>, but item at index 0 was <r>{"a": 1}</g>
 `;
 
 exports[`toBeStrictIterableOf should not match an iterable that contains a different value 2`] = `
 <d>expect(</b><r>received</g><d>).</b>toBeStrictIterableOf<d>(</b><g>expected</g><d>)</b>
 
-Expected <r>Set {{"a": 1}, {"a": 2}, {"a": 3}}</g> to contain only <g>{"a": Any<String>}</g> values, but item at index 0 was <r>{"a": 1}</g>
+Expected <r>Set {{"a": 1}, {"a": 2}, {"a": 3}}</g> to contain only values matching <g>{"a": Any<String>}</g>, but item at index 0 was <r>{"a": 1}</g>
 `;
 
 exports[`toBeStrictRecordOf should match a record that contains only the expected values 1`] = `
 <d>expect(</b><r>received</g><d>).</b>not<d>.</b>toBeStrictRecordOf<d>(</b><g>expected</g><d>)</b>
 
-Expected <r>{"a": {"a": 1}, "b": {"a": 2}}</g> not to contain only <g>{"a": Any<Number>}</g> values
+Expected <r>{"a": {"a": 1}, "b": {"a": 2}}</g> not to contain only values matching <g>{"a": Any<Number>}</g>
 `;
 
 exports[`toBeStrictRecordOf should match a record that contains only the expected values 2`] = `
 <d>expect(</b><r>received</g><d>).</b>toBeStrictRecordOf<d>(</b><g>expected</g><d>)</b>
 
-Expected <r>{"a": {"a": 1}, "b": {"a": 2}}</g> to contain only <g>{"a": Any<Number>, "b": undefined}</g> values, but item at key a was <r>{"a": 1}</g>
+Expected <r>{"a": {"a": 1}, "b": {"a": 2}}</g> to contain only values matching <g>{"a": Any<Number>, "b": undefined}</g>, but item at key a was <r>{"a": 1}</g>
 `;
 
 exports[`toBeStrictRecordOf should not match a non-record 1`] = `Expected <r>1</g> to be an object, but it was <r>"number"</g>`;
@@ -228,5 +228,5 @@ exports[`toBeStrictRecordOf should not match a non-record 1`] = `Expected <r>1</
 exports[`toBeStrictRecordOf should not match a record that contains a different value 1`] = `
 <d>expect(</b><r>received</g><d>).</b>toBeStrictRecordOf<d>(</b><g>expected</g><d>)</b>
 
-Expected <r>{"a": {"a": 1}, "b": {"a": 2}}</g> to contain only <g>{"a": Any<String>}</g> values, but item at key a was <r>{"a": 1}</g>
+Expected <r>{"a": {"a": 1}, "b": {"a": 2}}</g> to contain only values matching <g>{"a": Any<String>}</g>, but item at key a was <r>{"a": 1}</g>
 `;

--- a/src/shared/__vi_snapshots__/iterable-of.test.ts.snap
+++ b/src/shared/__vi_snapshots__/iterable-of.test.ts.snap
@@ -12,6 +12,10 @@ exports[`iterableOf > should not match an iterable that contains a different val
 
 exports[`recordOf > should match a record 1`] = `expected { a: 1, b: 2, c: 3 } to deeply equal not.recordOf<Any>`;
 
+exports[`recordOf > should match against keys 1`] = `expected { a: 1, b: 2, c: 3 } to deeply equal not.recordOf<oneOf, Any>`;
+
+exports[`recordOf > should match against keys 2`] = `expected { a: 1, b: 2, c: 3 } to deeply equal recordOf<oneOf, Any>`;
+
 exports[`recordOf > should not match a non-record 1`] = `expected 1 to deeply equal recordOf<1>`;
 
 exports[`recordOf > should not match a record that contains a different value 1`] = `expected { a: 1, b: 2, c: 3 } to deeply equal recordOf<Any>`;
@@ -33,6 +37,10 @@ exports[`strictIterableOf > should not match an iterable that contains a differe
 exports[`strictRecordOf > should match a record 1`] = `expected { a: { a: 1 }, b: { a: 2 } } to deeply equal not.strictRecordOf<[object Object]>`;
 
 exports[`strictRecordOf > should match a record 2`] = `expected { a: { a: 1 }, b: { a: 2 } } to deeply equal strictRecordOf<[object Object]>`;
+
+exports[`strictRecordOf > should match against keys 1`] = `expected { a: { a: 1 }, b: { a: 2 } } to deeply equal not.strictRecordOf{…}`;
+
+exports[`strictRecordOf > should match against keys 2`] = `expected { a: { a: 1 }, b: { a: 2 } } to deeply equal strictRecordOf<oneOf, [object Object]>`;
 
 exports[`strictRecordOf > should not match a non-record 1`] = `expected 1 to deeply equal strictRecordOf<1>`;
 
@@ -68,6 +76,18 @@ exports[`toBeRecordOf > should match a record that contains only the expected va
 <d>expect(</b><r>received</g><d>).</b>not<d>.</b>toBeRecordOf<d>(</b><g>expected</g><d>)</b>
 
 Expected <r>{"a": 1, "b": 2, "c": 3}</g> not to contain only values matching <g>Any<Number></g>
+`;
+
+exports[`toBeRecordOf > should match against keys 1`] = `
+<d>expect(</b><r>received</g><d>).</b>not<d>.</b>toBeRecordOf<d>(</b><g>expected</g><d>)</b>
+
+Expected <r>{"a": 1, "b": 2, "c": 3}</g> not to contain only values matching <g>Any<Number></g>
+`;
+
+exports[`toBeRecordOf > should match against keys 2`] = `
+<d>expect(</b><r>received</g><d>).</b>toBeRecordOf<d>(</b><g>expected</g><d>)</b>
+
+Expected <r>{"a": 1, "b": 2, "c": 3}</g> to contain only keys matching <g>oneOf<a,b></g>, but found key <r>"c"</g>
 `;
 
 exports[`toBeRecordOf > should not match a non-record 1`] = `Expected <r>1</g> to be an object, but it was <r>"number"</g>`;
@@ -126,6 +146,18 @@ exports[`toBeStrictRecordOf > should match a record that contains only the expec
 <d>expect(</b><r>received</g><d>).</b>toBeStrictRecordOf<d>(</b><g>expected</g><d>)</b>
 
 Expected <r>{"a": {"a": 1}, "b": {"a": 2}}</g> to contain only values matching <g>{"a": Any<Number>, "b": undefined}</g>, but item at key a was <r>{"a": 1}</g>
+`;
+
+exports[`toBeStrictRecordOf > should match against keys 1`] = `
+<d>expect(</b><r>received</g><d>).</b>not<d>.</b>toBeStrictRecordOf<d>(</b><g>expected</g><d>)</b>
+
+Expected <r>{"a": {"a": 1}, "b": {"a": 2}}</g> not to contain only values matching <g>{"a": Any<Number>}</g>
+`;
+
+exports[`toBeStrictRecordOf > should match against keys 2`] = `
+<d>expect(</b><r>received</g><d>).</b>toBeStrictRecordOf<d>(</b><g>expected</g><d>)</b>
+
+Expected <r>{"a": {"a": 1}, "b": {"a": 2}}</g> to contain only keys matching <g>oneOf<a></g>, but found key <r>"b"</g>
 `;
 
 exports[`toBeStrictRecordOf > should not match a non-record 1`] = `Expected <r>1</g> to be an object, but it was <r>"number"</g>`;

--- a/src/shared/__vi_snapshots__/iterable-of.test.ts.snap
+++ b/src/shared/__vi_snapshots__/iterable-of.test.ts.snap
@@ -41,13 +41,13 @@ exports[`strictRecordOf > should not match a record that contains a different va
 exports[`toBeIterableOf > should match an iterable that contains only the expected values 1`] = `
 <d>expect(</b><r>received</g><d>).</b>not<d>.</b>toBeIterableOf<d>(</b><g>expected</g><d>)</b>
 
-Expected <r>[1, 2, 3]</g> not to contain only <g>Any<Number></g> values
+Expected <r>[1, 2, 3]</g> not to contain only values matching <g>Any<Number></g>
 `;
 
 exports[`toBeIterableOf > should match an iterable that contains only the expected values 2`] = `
 <d>expect(</b><r>received</g><d>).</b>not<d>.</b>toBeIterableOf<d>(</b><g>expected</g><d>)</b>
 
-Expected <r>Set {1, 2, 3}</g> not to contain only <g>Any<Number></g> values
+Expected <r>Set {1, 2, 3}</g> not to contain only values matching <g>Any<Number></g>
 `;
 
 exports[`toBeIterableOf > should not match a non-iterable 1`] = `Expected <r>1</g> to be an iterable`;
@@ -55,19 +55,19 @@ exports[`toBeIterableOf > should not match a non-iterable 1`] = `Expected <r>1</
 exports[`toBeIterableOf > should not match an iterable that contains a different value 1`] = `
 <d>expect(</b><r>received</g><d>).</b>toBeIterableOf<d>(</b><g>expected</g><d>)</b>
 
-Expected <r>[1, 2, 3]</g> to contain only <g>Any<String></g> values, but item at index 0 was <r>1</g>
+Expected <r>[1, 2, 3]</g> to contain only values matching <g>Any<String></g>, but item at index 0 was <r>1</g>
 `;
 
 exports[`toBeIterableOf > should not match an iterable that contains a different value 2`] = `
 <d>expect(</b><r>received</g><d>).</b>toBeIterableOf<d>(</b><g>expected</g><d>)</b>
 
-Expected <r>Set {1, 2, 3}</g> to contain only <g>Any<String></g> values, but item at index 0 was <r>1</g>
+Expected <r>Set {1, 2, 3}</g> to contain only values matching <g>Any<String></g>, but item at index 0 was <r>1</g>
 `;
 
 exports[`toBeRecordOf > should match a record that contains only the expected values 1`] = `
 <d>expect(</b><r>received</g><d>).</b>not<d>.</b>toBeRecordOf<d>(</b><g>expected</g><d>)</b>
 
-Expected <r>{"a": 1, "b": 2, "c": 3}</g> not to contain only <g>Any<Number></g> values
+Expected <r>{"a": 1, "b": 2, "c": 3}</g> not to contain only values matching <g>Any<Number></g>
 `;
 
 exports[`toBeRecordOf > should not match a non-record 1`] = `Expected <r>1</g> to be an object, but it was <r>"number"</g>`;
@@ -75,31 +75,31 @@ exports[`toBeRecordOf > should not match a non-record 1`] = `Expected <r>1</g> t
 exports[`toBeRecordOf > should not match a record that contains a different value 1`] = `
 <d>expect(</b><r>received</g><d>).</b>toBeRecordOf<d>(</b><g>expected</g><d>)</b>
 
-Expected <r>{"a": 1, "b": 2, "c": 3}</g> to contain only <g>Any<String></g> values, but item at key a was <r>1</g>
+Expected <r>{"a": 1, "b": 2, "c": 3}</g> to contain only values matching <g>Any<String></g>, but item at key a was <r>1</g>
 `;
 
 exports[`toBeStrictIterableOf > should match an iterable that contains only the expected values 1`] = `
 <d>expect(</b><r>received</g><d>).</b>not<d>.</b>toBeStrictIterableOf<d>(</b><g>expected</g><d>)</b>
 
-Expected <r>[{"a": 1}, {"a": 2}, {"a": 3}]</g> not to contain only <g>{"a": Any<Number>}</g> values
+Expected <r>[{"a": 1}, {"a": 2}, {"a": 3}]</g> not to contain only values matching <g>{"a": Any<Number>}</g>
 `;
 
 exports[`toBeStrictIterableOf > should match an iterable that contains only the expected values 2`] = `
 <d>expect(</b><r>received</g><d>).</b>toBeStrictIterableOf<d>(</b><g>expected</g><d>)</b>
 
-Expected <r>[{"a": 1}, {"a": 2}, {"a": 3}]</g> to contain only <g>{"a": Any<Number>, "b": undefined}</g> values, but item at index 0 was <r>{"a": 1}</g>
+Expected <r>[{"a": 1}, {"a": 2}, {"a": 3}]</g> to contain only values matching <g>{"a": Any<Number>, "b": undefined}</g>, but item at index 0 was <r>{"a": 1}</g>
 `;
 
 exports[`toBeStrictIterableOf > should match an iterable that contains only the expected values 3`] = `
 <d>expect(</b><r>received</g><d>).</b>not<d>.</b>toBeStrictIterableOf<d>(</b><g>expected</g><d>)</b>
 
-Expected <r>Set {{"a": 1}, {"a": 2}, {"a": 3}}</g> not to contain only <g>{"a": Any<Number>}</g> values
+Expected <r>Set {{"a": 1}, {"a": 2}, {"a": 3}}</g> not to contain only values matching <g>{"a": Any<Number>}</g>
 `;
 
 exports[`toBeStrictIterableOf > should match an iterable that contains only the expected values 4`] = `
 <d>expect(</b><r>received</g><d>).</b>toBeStrictIterableOf<d>(</b><g>expected</g><d>)</b>
 
-Expected <r>Set {{"a": 1}, {"a": 2}, {"a": 3}}</g> to contain only <g>{"a": Any<Number>, "b": undefined}</g> values, but item at index 0 was <r>{"a": 1}</g>
+Expected <r>Set {{"a": 1}, {"a": 2}, {"a": 3}}</g> to contain only values matching <g>{"a": Any<Number>, "b": undefined}</g>, but item at index 0 was <r>{"a": 1}</g>
 `;
 
 exports[`toBeStrictIterableOf > should not match a non-iterable 1`] = `Expected <r>1</g> to be an iterable`;
@@ -107,25 +107,25 @@ exports[`toBeStrictIterableOf > should not match a non-iterable 1`] = `Expected 
 exports[`toBeStrictIterableOf > should not match an iterable that contains a different value 1`] = `
 <d>expect(</b><r>received</g><d>).</b>toBeStrictIterableOf<d>(</b><g>expected</g><d>)</b>
 
-Expected <r>[{"a": 1}, {"a": 2}, {"a": 3}]</g> to contain only <g>{"a": Any<String>}</g> values, but item at index 0 was <r>{"a": 1}</g>
+Expected <r>[{"a": 1}, {"a": 2}, {"a": 3}]</g> to contain only values matching <g>{"a": Any<String>}</g>, but item at index 0 was <r>{"a": 1}</g>
 `;
 
 exports[`toBeStrictIterableOf > should not match an iterable that contains a different value 2`] = `
 <d>expect(</b><r>received</g><d>).</b>toBeStrictIterableOf<d>(</b><g>expected</g><d>)</b>
 
-Expected <r>Set {{"a": 1}, {"a": 2}, {"a": 3}}</g> to contain only <g>{"a": Any<String>}</g> values, but item at index 0 was <r>{"a": 1}</g>
+Expected <r>Set {{"a": 1}, {"a": 2}, {"a": 3}}</g> to contain only values matching <g>{"a": Any<String>}</g>, but item at index 0 was <r>{"a": 1}</g>
 `;
 
 exports[`toBeStrictRecordOf > should match a record that contains only the expected values 1`] = `
 <d>expect(</b><r>received</g><d>).</b>not<d>.</b>toBeStrictRecordOf<d>(</b><g>expected</g><d>)</b>
 
-Expected <r>{"a": {"a": 1}, "b": {"a": 2}}</g> not to contain only <g>{"a": Any<Number>}</g> values
+Expected <r>{"a": {"a": 1}, "b": {"a": 2}}</g> not to contain only values matching <g>{"a": Any<Number>}</g>
 `;
 
 exports[`toBeStrictRecordOf > should match a record that contains only the expected values 2`] = `
 <d>expect(</b><r>received</g><d>).</b>toBeStrictRecordOf<d>(</b><g>expected</g><d>)</b>
 
-Expected <r>{"a": {"a": 1}, "b": {"a": 2}}</g> to contain only <g>{"a": Any<Number>, "b": undefined}</g> values, but item at key a was <r>{"a": 1}</g>
+Expected <r>{"a": {"a": 1}, "b": {"a": 2}}</g> to contain only values matching <g>{"a": Any<Number>, "b": undefined}</g>, but item at key a was <r>{"a": 1}</g>
 `;
 
 exports[`toBeStrictRecordOf > should not match a non-record 1`] = `Expected <r>1</g> to be an object, but it was <r>"number"</g>`;
@@ -133,5 +133,5 @@ exports[`toBeStrictRecordOf > should not match a non-record 1`] = `Expected <r>1
 exports[`toBeStrictRecordOf > should not match a record that contains a different value 1`] = `
 <d>expect(</b><r>received</g><d>).</b>toBeStrictRecordOf<d>(</b><g>expected</g><d>)</b>
 
-Expected <r>{"a": {"a": 1}, "b": {"a": 2}}</g> to contain only <g>{"a": Any<String>}</g> values, but item at key a was <r>{"a": 1}</g>
+Expected <r>{"a": {"a": 1}, "b": {"a": 2}}</g> to contain only values matching <g>{"a": Any<String>}</g>, but item at key a was <r>{"a": 1}</g>
 `;

--- a/src/shared/__vi_snapshots__/iterable-of.test.ts.snap
+++ b/src/shared/__vi_snapshots__/iterable-of.test.ts.snap
@@ -1,0 +1,137 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`iterableOf > should match an iterable 1`] = `expected [ 1, 2, 3 ] to deeply equal not.iterableOf<Any>`;
+
+exports[`iterableOf > should match an iterable 2`] = `expected Set{ 1, 2, 3 } to deeply equal not.iterableOf<Any>`;
+
+exports[`iterableOf > should not match a non-iterable 1`] = `expected 1 to deeply equal iterableOf<1>`;
+
+exports[`iterableOf > should not match an iterable that contains a different value 1`] = `expected [ 1, 2, 3 ] to deeply equal iterableOf<Any>`;
+
+exports[`iterableOf > should not match an iterable that contains a different value 2`] = `expected Set{ 1, 2, 3 } to deeply equal iterableOf<Any>`;
+
+exports[`recordOf > should match a record 1`] = `expected { a: 1, b: 2, c: 3 } to deeply equal not.recordOf<Any>`;
+
+exports[`recordOf > should not match a non-record 1`] = `expected 1 to deeply equal recordOf<1>`;
+
+exports[`recordOf > should not match a record that contains a different value 1`] = `expected { a: 1, b: 2, c: 3 } to deeply equal recordOf<Any>`;
+
+exports[`strictIterableOf > should match an iterable 1`] = `expected [ { a: 1 }, { a: 2 }, { a: 3 } ] to deeply equal not.strictIterableOf<[object Object]>`;
+
+exports[`strictIterableOf > should match an iterable 2`] = `expected [ { a: 1 }, { a: 2 }, { a: 3 } ] to deeply equal strictIterableOf<[object Object]>`;
+
+exports[`strictIterableOf > should match an iterable 3`] = `expected Set{ { a: 1 }, { a: 2 }, { a: 3 } } to deeply equal not.strictIterableOf<[object Object]>`;
+
+exports[`strictIterableOf > should match an iterable 4`] = `expected Set{ { a: 1 }, { a: 2 }, { a: 3 } } to deeply equal strictIterableOf<[object Object]>`;
+
+exports[`strictIterableOf > should not match a non-iterable 1`] = `expected 1 to deeply equal strictIterableOf<1>`;
+
+exports[`strictIterableOf > should not match an iterable that contains a different value 1`] = `expected [ { a: 1 }, { a: 2 }, { a: 3 } ] to deeply equal strictIterableOf<[object Object]>`;
+
+exports[`strictIterableOf > should not match an iterable that contains a different value 2`] = `expected Set{ { a: 1 }, { a: 2 }, { a: 3 } } to deeply equal strictIterableOf<[object Object]>`;
+
+exports[`strictRecordOf > should match a record 1`] = `expected { a: { a: 1 }, b: { a: 2 } } to deeply equal not.strictRecordOf<[object Object]>`;
+
+exports[`strictRecordOf > should match a record 2`] = `expected { a: { a: 1 }, b: { a: 2 } } to deeply equal strictRecordOf<[object Object]>`;
+
+exports[`strictRecordOf > should not match a non-record 1`] = `expected 1 to deeply equal strictRecordOf<1>`;
+
+exports[`strictRecordOf > should not match a record that contains a different value 1`] = `expected { a: { a: 1 }, b: { a: 2 } } to deeply equal strictRecordOf<[object Object]>`;
+
+exports[`toBeIterableOf > should match an iterable that contains only the expected values 1`] = `
+<d>expect(</b><r>received</g><d>).</b>not<d>.</b>toBeIterableOf<d>(</b><g>expected</g><d>)</b>
+
+Expected <r>[1, 2, 3]</g> not to contain only <g>Any<Number></g> values
+`;
+
+exports[`toBeIterableOf > should match an iterable that contains only the expected values 2`] = `
+<d>expect(</b><r>received</g><d>).</b>not<d>.</b>toBeIterableOf<d>(</b><g>expected</g><d>)</b>
+
+Expected <r>Set {1, 2, 3}</g> not to contain only <g>Any<Number></g> values
+`;
+
+exports[`toBeIterableOf > should not match a non-iterable 1`] = `Expected <r>1</g> to be an iterable`;
+
+exports[`toBeIterableOf > should not match an iterable that contains a different value 1`] = `
+<d>expect(</b><r>received</g><d>).</b>toBeIterableOf<d>(</b><g>expected</g><d>)</b>
+
+Expected <r>[1, 2, 3]</g> to contain only <g>Any<String></g> values, but item at index 0 was <r>1</g>
+`;
+
+exports[`toBeIterableOf > should not match an iterable that contains a different value 2`] = `
+<d>expect(</b><r>received</g><d>).</b>toBeIterableOf<d>(</b><g>expected</g><d>)</b>
+
+Expected <r>Set {1, 2, 3}</g> to contain only <g>Any<String></g> values, but item at index 0 was <r>1</g>
+`;
+
+exports[`toBeRecordOf > should match a record that contains only the expected values 1`] = `
+<d>expect(</b><r>received</g><d>).</b>not<d>.</b>toBeRecordOf<d>(</b><g>expected</g><d>)</b>
+
+Expected <r>{"a": 1, "b": 2, "c": 3}</g> not to contain only <g>Any<Number></g> values
+`;
+
+exports[`toBeRecordOf > should not match a non-record 1`] = `Expected <r>1</g> to be an object, but it was <r>"number"</g>`;
+
+exports[`toBeRecordOf > should not match a record that contains a different value 1`] = `
+<d>expect(</b><r>received</g><d>).</b>toBeRecordOf<d>(</b><g>expected</g><d>)</b>
+
+Expected <r>{"a": 1, "b": 2, "c": 3}</g> to contain only <g>Any<String></g> values, but item at key a was <r>1</g>
+`;
+
+exports[`toBeStrictIterableOf > should match an iterable that contains only the expected values 1`] = `
+<d>expect(</b><r>received</g><d>).</b>not<d>.</b>toBeStrictIterableOf<d>(</b><g>expected</g><d>)</b>
+
+Expected <r>[{"a": 1}, {"a": 2}, {"a": 3}]</g> not to contain only <g>{"a": Any<Number>}</g> values
+`;
+
+exports[`toBeStrictIterableOf > should match an iterable that contains only the expected values 2`] = `
+<d>expect(</b><r>received</g><d>).</b>toBeStrictIterableOf<d>(</b><g>expected</g><d>)</b>
+
+Expected <r>[{"a": 1}, {"a": 2}, {"a": 3}]</g> to contain only <g>{"a": Any<Number>, "b": undefined}</g> values, but item at index 0 was <r>{"a": 1}</g>
+`;
+
+exports[`toBeStrictIterableOf > should match an iterable that contains only the expected values 3`] = `
+<d>expect(</b><r>received</g><d>).</b>not<d>.</b>toBeStrictIterableOf<d>(</b><g>expected</g><d>)</b>
+
+Expected <r>Set {{"a": 1}, {"a": 2}, {"a": 3}}</g> not to contain only <g>{"a": Any<Number>}</g> values
+`;
+
+exports[`toBeStrictIterableOf > should match an iterable that contains only the expected values 4`] = `
+<d>expect(</b><r>received</g><d>).</b>toBeStrictIterableOf<d>(</b><g>expected</g><d>)</b>
+
+Expected <r>Set {{"a": 1}, {"a": 2}, {"a": 3}}</g> to contain only <g>{"a": Any<Number>, "b": undefined}</g> values, but item at index 0 was <r>{"a": 1}</g>
+`;
+
+exports[`toBeStrictIterableOf > should not match a non-iterable 1`] = `Expected <r>1</g> to be an iterable`;
+
+exports[`toBeStrictIterableOf > should not match an iterable that contains a different value 1`] = `
+<d>expect(</b><r>received</g><d>).</b>toBeStrictIterableOf<d>(</b><g>expected</g><d>)</b>
+
+Expected <r>[{"a": 1}, {"a": 2}, {"a": 3}]</g> to contain only <g>{"a": Any<String>}</g> values, but item at index 0 was <r>{"a": 1}</g>
+`;
+
+exports[`toBeStrictIterableOf > should not match an iterable that contains a different value 2`] = `
+<d>expect(</b><r>received</g><d>).</b>toBeStrictIterableOf<d>(</b><g>expected</g><d>)</b>
+
+Expected <r>Set {{"a": 1}, {"a": 2}, {"a": 3}}</g> to contain only <g>{"a": Any<String>}</g> values, but item at index 0 was <r>{"a": 1}</g>
+`;
+
+exports[`toBeStrictRecordOf > should match a record that contains only the expected values 1`] = `
+<d>expect(</b><r>received</g><d>).</b>not<d>.</b>toBeStrictRecordOf<d>(</b><g>expected</g><d>)</b>
+
+Expected <r>{"a": {"a": 1}, "b": {"a": 2}}</g> not to contain only <g>{"a": Any<Number>}</g> values
+`;
+
+exports[`toBeStrictRecordOf > should match a record that contains only the expected values 2`] = `
+<d>expect(</b><r>received</g><d>).</b>toBeStrictRecordOf<d>(</b><g>expected</g><d>)</b>
+
+Expected <r>{"a": {"a": 1}, "b": {"a": 2}}</g> to contain only <g>{"a": Any<Number>, "b": undefined}</g> values, but item at key a was <r>{"a": 1}</g>
+`;
+
+exports[`toBeStrictRecordOf > should not match a non-record 1`] = `Expected <r>1</g> to be an object, but it was <r>"number"</g>`;
+
+exports[`toBeStrictRecordOf > should not match a record that contains a different value 1`] = `
+<d>expect(</b><r>received</g><d>).</b>toBeStrictRecordOf<d>(</b><g>expected</g><d>)</b>
+
+Expected <r>{"a": {"a": 1}, "b": {"a": 2}}</g> to contain only <g>{"a": Any<String>}</g> values, but item at key a was <r>{"a": 1}</g>
+`;

--- a/src/shared/iterable-of.test.ts
+++ b/src/shared/iterable-of.test.ts
@@ -1,0 +1,311 @@
+import { describe, it, expect } from "@globals";
+
+describe("toBeIterableOf", () => {
+  it("should match an iterable that contains only the expected values", () => {
+    expect([1, 2, 3]).toBeIterableOf(expect.any(Number));
+    expect(() => {
+      expect([1, 2, 3]).not.toBeIterableOf(expect.any(Number));
+    }).toThrowErrorMatchingSnapshot();
+
+    expect(new Set([1, 2, 3])).toBeIterableOf(expect.any(Number));
+    expect(() => {
+      expect(new Set([1, 2, 3])).not.toBeIterableOf(expect.any(Number));
+    }).toThrowErrorMatchingSnapshot();
+  });
+
+  it("should not match an iterable that contains a different value", () => {
+    expect([1, 2, 3]).not.toBeIterableOf(expect.any(String));
+    expect(() => {
+      expect([1, 2, 3]).toBeIterableOf(expect.any(String));
+    }).toThrowErrorMatchingSnapshot();
+
+    expect(new Set([1, 2, 3])).not.toBeIterableOf(expect.any(String));
+
+    expect(() => {
+      expect(new Set([1, 2, 3])).toBeIterableOf(expect.any(String));
+    }).toThrowErrorMatchingSnapshot();
+  });
+
+  it("should not match a non-iterable", () => {
+    expect(1).not.toBeIterableOf(1);
+    expect(() => {
+      expect(1).toBeIterableOf(1);
+    }).toThrowErrorMatchingSnapshot();
+  });
+});
+
+describe("toBeStrictIterableOf", () => {
+  it("should match an iterable that contains only the expected values", () => {
+    expect([{ a: 1 }, { a: 2 }, { a: 3 }]).toBeStrictIterableOf({
+      a: expect.any(Number),
+    });
+    expect(() => {
+      expect([{ a: 1 }, { a: 2 }, { a: 3 }]).not.toBeStrictIterableOf({
+        a: expect.any(Number),
+      });
+    }).toThrowErrorMatchingSnapshot();
+    expect(() => {
+      expect([{ a: 1 }, { a: 2 }, { a: 3 }]).toBeStrictIterableOf({
+        a: expect.any(Number),
+        b: undefined,
+      });
+    }).toThrowErrorMatchingSnapshot();
+
+    expect(new Set([{ a: 1 }, { a: 2 }, { a: 3 }])).toBeStrictIterableOf({
+      a: expect.any(Number),
+    });
+    expect(() => {
+      expect(new Set([{ a: 1 }, { a: 2 }, { a: 3 }])).not.toBeStrictIterableOf({
+        a: expect.any(Number),
+      });
+    }).toThrowErrorMatchingSnapshot();
+    expect(() => {
+      expect(new Set([{ a: 1 }, { a: 2 }, { a: 3 }])).toBeStrictIterableOf({
+        a: expect.any(Number),
+        b: undefined,
+      });
+    }).toThrowErrorMatchingSnapshot();
+  });
+
+  it("should not match an iterable that contains a different value", () => {
+    expect([{ a: 1 }, { a: 2 }, { a: 3 }]).not.toBeStrictIterableOf({
+      a: expect.any(String),
+    });
+    expect(() => {
+      expect([{ a: 1 }, { a: 2 }, { a: 3 }]).toBeStrictIterableOf({
+        a: expect.any(String),
+      });
+    }).toThrowErrorMatchingSnapshot();
+
+    expect(new Set([{ a: 1 }, { a: 2 }, { a: 3 }])).not.toBeStrictIterableOf({
+      a: expect.any(String),
+    });
+    expect(() => {
+      expect(new Set([{ a: 1 }, { a: 2 }, { a: 3 }])).toBeStrictIterableOf({
+        a: expect.any(String),
+      });
+    }).toThrowErrorMatchingSnapshot();
+  });
+
+  it("should not match a non-iterable", () => {
+    expect(1).not.toBeStrictIterableOf(1);
+    expect(() => {
+      expect(1).toBeStrictIterableOf(1);
+    }).toThrowErrorMatchingSnapshot();
+  });
+});
+
+describe("toBeRecordOf", () => {
+  it("should match a record that contains only the expected values", () => {
+    expect({ a: 1, b: 2, c: 3 }).toBeRecordOf(expect.any(Number));
+    expect(() => {
+      expect({ a: 1, b: 2, c: 3 }).not.toBeRecordOf(expect.any(Number));
+    }).toThrowErrorMatchingSnapshot();
+  });
+
+  it("should not match a record that contains a different value", () => {
+    expect({ a: 1, b: 2, c: 3 }).not.toBeRecordOf(expect.any(String));
+    expect(() => {
+      expect({ a: 1, b: 2, c: 3 }).toBeRecordOf(expect.any(String));
+    }).toThrowErrorMatchingSnapshot();
+  });
+
+  it("should not match a non-record", () => {
+    expect(1).not.toBeRecordOf(1);
+    expect(() => {
+      expect(1).toBeRecordOf(1);
+    }).toThrowErrorMatchingSnapshot();
+  });
+});
+
+describe("toBeStrictRecordOf", () => {
+  it("should match a record that contains only the expected values", () => {
+    expect({ a: { a: 1 }, b: { a: 2 } }).toBeStrictRecordOf({
+      a: expect.any(Number),
+    });
+    expect(() => {
+      expect({ a: { a: 1 }, b: { a: 2 } }).not.toBeStrictRecordOf({
+        a: expect.any(Number),
+      });
+    }).toThrowErrorMatchingSnapshot();
+    expect(() => {
+      expect({ a: { a: 1 }, b: { a: 2 } }).toBeStrictRecordOf({
+        a: expect.any(Number),
+        b: undefined,
+      });
+    }).toThrowErrorMatchingSnapshot();
+  });
+
+  it("should not match a record that contains a different value", () => {
+    expect({ a: { a: 1 }, b: { a: 2 } }).not.toBeStrictRecordOf({
+      a: expect.any(String),
+    });
+    expect(() => {
+      expect({ a: { a: 1 }, b: { a: 2 } }).toBeStrictRecordOf({
+        a: expect.any(String),
+      });
+    }).toThrowErrorMatchingSnapshot();
+  });
+
+  it("should not match a non-record", () => {
+    expect(1).not.toBeStrictRecordOf(1);
+    expect(() => {
+      expect(1).toBeStrictRecordOf(1);
+    }).toThrowErrorMatchingSnapshot();
+  });
+});
+
+describe("iterableOf", () => {
+  it("should match an iterable", () => {
+    expect([1, 2, 3]).toEqual(expect.iterableOf(expect.any(Number)));
+    expect(() => {
+      expect([1, 2, 3]).toEqual(expect.not.iterableOf(expect.any(Number)));
+    }).toThrowErrorMatchingSnapshot();
+
+    expect(new Set([1, 2, 3])).toEqual(expect.iterableOf(expect.any(Number)));
+    expect(() => {
+      expect(new Set([1, 2, 3])).toEqual(
+        expect.not.iterableOf(expect.any(Number)),
+      );
+    }).toThrowErrorMatchingSnapshot();
+  });
+
+  it("should not match an iterable that contains a different value", () => {
+    expect([1, 2, 3]).toEqual(expect.not.iterableOf(expect.any(String)));
+    expect(() => {
+      expect([1, 2, 3]).toEqual(expect.iterableOf(expect.any(String)));
+    }).toThrowErrorMatchingSnapshot();
+
+    expect(new Set([1, 2, 3])).toEqual(
+      expect.not.iterableOf(expect.any(String)),
+    );
+    expect(() => {
+      expect(new Set([1, 2, 3])).toEqual(expect.iterableOf(expect.any(String)));
+    }).toThrowErrorMatchingSnapshot();
+  });
+
+  it("should not match a non-iterable", () => {
+    expect(() => {
+      expect(1).toEqual(expect.iterableOf(1));
+    }).toThrowErrorMatchingSnapshot();
+  });
+});
+
+describe("strictIterableOf", () => {
+  it("should match an iterable", () => {
+    expect([{ a: 1 }, { a: 2 }, { a: 3 }]).toEqual(
+      expect.strictIterableOf({ a: expect.any(Number) }),
+    );
+    expect(() => {
+      expect([{ a: 1 }, { a: 2 }, { a: 3 }]).toEqual(
+        expect.not.strictIterableOf({ a: expect.any(Number) }),
+      );
+    }).toThrowErrorMatchingSnapshot();
+    expect(() => {
+      expect([{ a: 1 }, { a: 2 }, { a: 3 }]).toEqual(
+        expect.strictIterableOf({ a: expect.any(Number), b: undefined }),
+      );
+    }).toThrowErrorMatchingSnapshot();
+
+    expect(new Set([{ a: 1 }, { a: 2 }, { a: 3 }])).toEqual(
+      expect.strictIterableOf({ a: expect.any(Number) }),
+    );
+    expect(() => {
+      expect(new Set([{ a: 1 }, { a: 2 }, { a: 3 }])).toEqual(
+        expect.not.strictIterableOf({ a: expect.any(Number) }),
+      );
+    }).toThrowErrorMatchingSnapshot();
+    expect(() => {
+      expect(new Set([{ a: 1 }, { a: 2 }, { a: 3 }])).toEqual(
+        expect.strictIterableOf({ a: expect.any(Number), b: undefined }),
+      );
+    }).toThrowErrorMatchingSnapshot();
+  });
+
+  it("should not match an iterable that contains a different value", () => {
+    expect([{ a: 1 }, { a: 2 }, { a: 3 }]).not.toEqual(
+      expect.strictIterableOf({ a: expect.any(String) }),
+    );
+    expect(() => {
+      expect([{ a: 1 }, { a: 2 }, { a: 3 }]).toEqual(
+        expect.strictIterableOf({ a: expect.any(String) }),
+      );
+    }).toThrowErrorMatchingSnapshot();
+
+    expect(new Set([{ a: 1 }, { a: 2 }, { a: 3 }])).toEqual(
+      expect.not.strictIterableOf({ a: expect.any(String) }),
+    );
+    expect(() => {
+      expect(new Set([{ a: 1 }, { a: 2 }, { a: 3 }])).toEqual(
+        expect.strictIterableOf({ a: expect.any(String) }),
+      );
+    }).toThrowErrorMatchingSnapshot();
+  });
+
+  it("should not match a non-iterable", () => {
+    expect(() => {
+      expect(1).toEqual(expect.strictIterableOf(1));
+    }).toThrowErrorMatchingSnapshot();
+  });
+});
+
+describe("recordOf", () => {
+  it("should match a record", () => {
+    expect({ a: 1, b: 2, c: 3 }).toEqual(expect.recordOf(expect.any(Number)));
+    expect(() => {
+      expect({ a: 1, b: 2, c: 3 }).toEqual(
+        expect.not.recordOf(expect.any(Number)),
+      );
+    }).toThrowErrorMatchingSnapshot();
+  });
+
+  it("should not match a record that contains a different value", () => {
+    expect({ a: 1, b: 2, c: 3 }).toEqual(
+      expect.not.recordOf(expect.any(String)),
+    );
+    expect(() => {
+      expect({ a: 1, b: 2, c: 3 }).toEqual(expect.recordOf(expect.any(String)));
+    }).toThrowErrorMatchingSnapshot();
+  });
+
+  it("should not match a non-record", () => {
+    expect(() => {
+      expect(1).toEqual(expect.recordOf(1));
+    }).toThrowErrorMatchingSnapshot();
+  });
+});
+
+describe("strictRecordOf", () => {
+  it("should match a record", () => {
+    expect({ a: { a: 1 }, b: { a: 2 } }).toEqual(
+      expect.strictRecordOf({ a: expect.any(Number) }),
+    );
+    expect(() => {
+      expect({ a: { a: 1 }, b: { a: 2 } }).toEqual(
+        expect.not.strictRecordOf({ a: expect.any(Number) }),
+      );
+    }).toThrowErrorMatchingSnapshot();
+    expect(() => {
+      expect({ a: { a: 1 }, b: { a: 2 } }).toEqual(
+        expect.strictRecordOf({ a: expect.any(Number), b: undefined }),
+      );
+    }).toThrowErrorMatchingSnapshot();
+  });
+
+  it("should not match a record that contains a different value", () => {
+    expect({ a: { a: 1 }, b: { a: 2 } }).toEqual(
+      expect.not.strictRecordOf({ a: expect.any(String) }),
+    );
+    expect(() => {
+      expect({ a: { a: 1 }, b: { a: 2 } }).toEqual(
+        expect.strictRecordOf({ a: expect.any(String) }),
+      );
+    }).toThrowErrorMatchingSnapshot();
+  });
+
+  it("should not match a non-record", () => {
+    expect(() => {
+      expect(1).toEqual(expect.strictRecordOf(1));
+    }).toThrowErrorMatchingSnapshot();
+  });
+});

--- a/src/shared/iterable-of.test.ts
+++ b/src/shared/iterable-of.test.ts
@@ -110,6 +110,25 @@ describe("toBeRecordOf", () => {
     }).toThrowErrorMatchingSnapshot();
   });
 
+  it("should match against keys", () => {
+    expect({ a: 1, b: 2, c: 3 }).toBeRecordOf(
+      expect.oneOf(["a", "b", "c"]),
+      expect.any(Number),
+    );
+    expect(() => {
+      expect({ a: 1, b: 2, c: 3 }).not.toBeRecordOf(
+        expect.oneOf(["a", "b", "c"]),
+        expect.any(Number),
+      );
+    }).toThrowErrorMatchingSnapshot();
+    expect(() => {
+      expect({ a: 1, b: 2, c: 3 }).toBeRecordOf(
+        expect.oneOf(["a", "b"]),
+        expect.any(Number),
+      );
+    }).toThrowErrorMatchingSnapshot();
+  });
+
   it("should not match a non-record", () => {
     expect(1).not.toBeRecordOf(1);
     expect(() => {
@@ -144,6 +163,25 @@ describe("toBeStrictRecordOf", () => {
       expect({ a: { a: 1 }, b: { a: 2 } }).toBeStrictRecordOf({
         a: expect.any(String),
       });
+    }).toThrowErrorMatchingSnapshot();
+  });
+
+  it("should match against keys", () => {
+    expect({ a: { a: 1 }, b: { a: 2 } }).toBeStrictRecordOf(
+      expect.oneOf(["a", "b"]),
+      { a: expect.any(Number) },
+    );
+    expect(() => {
+      expect({ a: { a: 1 }, b: { a: 2 } }).not.toBeStrictRecordOf(
+        expect.oneOf(["a", "b"]),
+        { a: expect.any(Number) },
+      );
+    }).toThrowErrorMatchingSnapshot();
+    expect(() => {
+      expect({ a: { a: 1 }, b: { a: 2 } }).toBeStrictRecordOf(
+        expect.oneOf(["a"]),
+        { a: expect.any(Number) },
+      );
     }).toThrowErrorMatchingSnapshot();
   });
 
@@ -268,6 +306,22 @@ describe("recordOf", () => {
     }).toThrowErrorMatchingSnapshot();
   });
 
+  it("should match against keys", () => {
+    expect({ a: 1, b: 2, c: 3 }).toEqual(
+      expect.recordOf(expect.oneOf(["a", "b", "c"]), expect.any(Number)),
+    );
+    expect(() => {
+      expect({ a: 1, b: 2, c: 3 }).toEqual(
+        expect.not.recordOf(expect.oneOf(["a", "b", "c"]), expect.any(Number)),
+      );
+    }).toThrowErrorMatchingSnapshot();
+    expect(() => {
+      expect({ a: 1, b: 2, c: 3 }).toEqual(
+        expect.recordOf(expect.oneOf(["a", "b"]), expect.any(Number)),
+      );
+    }).toThrowErrorMatchingSnapshot();
+  });
+
   it("should not match a non-record", () => {
     expect(() => {
       expect(1).toEqual(expect.recordOf(1));
@@ -299,6 +353,26 @@ describe("strictRecordOf", () => {
     expect(() => {
       expect({ a: { a: 1 }, b: { a: 2 } }).toEqual(
         expect.strictRecordOf({ a: expect.any(String) }),
+      );
+    }).toThrowErrorMatchingSnapshot();
+  });
+
+  it("should match against keys", () => {
+    expect({ a: { a: 1 }, b: { a: 2 } }).toEqual(
+      expect.strictRecordOf(expect.oneOf(["a", "b"]), {
+        a: expect.any(Number),
+      }),
+    );
+    expect(() => {
+      expect({ a: { a: 1 }, b: { a: 2 } }).toEqual(
+        expect.not.strictRecordOf(expect.oneOf(["a", "b"]), {
+          a: expect.any(Number),
+        }),
+      );
+    }).toThrowErrorMatchingSnapshot();
+    expect(() => {
+      expect({ a: { a: 1 }, b: { a: 2 } }).toEqual(
+        expect.strictRecordOf(expect.oneOf(["a"]), { a: expect.any(Number) }),
       );
     }).toThrowErrorMatchingSnapshot();
   });

--- a/src/shared/iterable-of.ts
+++ b/src/shared/iterable-of.ts
@@ -42,16 +42,52 @@ const makeIterableOfMatcher = (
     };
   };
 
+/**
+ * Asserts that a value is an iterable where all items are deeply equal to the expected value.
+ *
+ * @example
+ * expect([1, 1, 1]).toBeIterableOf(1);
+ * expect([1, 1, 2]).not.toBeIterableOf(1);
+ *
+ * expect([1, 2, 1]).toBeIterableOf(expect.any(Number));
+ */
 export const toBeIterableOf = makeIterableOfMatcher("toBeIterableOf", false);
 
+/**
+ * Matches an iterable where all items are deeply equal to the expected value.
+ *
+ * @example
+ * expect({ value: [1, 1, 1] }).toEqual({ value: expect.iterableOf(1) });
+ * expect({ value: [1, 1, 2] }).not.toEqual({ value: expect.iterableOf(1) });
+ *
+ * expect({ value: [1, 2, 1] }).toEqual({ value: expect.iterableOf(expect.any(Number)) });
+ */
 export const iterableOf = makeIterableOfMatcher("iterableOf", true);
 
+/**
+ * Asserts that a value is an iterable where all items are strictly deeply equal to the expected value.
+ *
+ * @example
+ * expect([1, 1, 1]).toBeStrictIterableOf(1);
+ * expect([1, 1, 2]).not.toBeStrictIterableOf(1);
+ *
+ * expect([1, 2, 1]).toBeStrictIterableOf(expect.any(Number));
+ */
 export const toBeStrictIterableOf = makeIterableOfMatcher(
   "toBeStrictIterableOf",
   false,
   true,
 );
 
+/**
+ * Matches an iterable where all items are strictly deeply equal to the expected value.
+ *
+ * @example
+ * expect({ value: [1, 1, 1] }).toEqual({ value: expect.strictIterableOf(1) });
+ * expect({ value: [1, 1, 2] }).not.toEqual({ value: expect.strictIterableOf(1) });
+ *
+ * expect({ value: [1, 2, 1] }).toEqual({ value: expect.strictIterableOf(expect.any(Number)) });
+ */
 export const strictIterableOf = makeIterableOfMatcher(
   "strictIterableOf",
   true,
@@ -79,13 +115,13 @@ const makeRecordOfMatcher = (
       }) + "\n\n";
     const equalValue = makeEqualValue(this);
 
-    for (const key of Object.keys(received)) {
-      if (!equalValue((received as any)[key], expected, strict)) {
+    for (const [key, value] of Object.entries(received)) {
+      if (!equalValue(value, expected, strict)) {
         return {
           pass: false,
           message: () =>
             prefix +
-            `Expected ${printReceived(received)} to contain only ${printExpected(expected)} values, but item at key ${key} was ${printReceived((received as any)[key])}`,
+            `Expected ${printReceived(received)} to contain only ${printExpected(expected)} values, but item at key ${key} was ${printReceived(value)}`,
         };
       }
     }
@@ -97,29 +133,137 @@ const makeRecordOfMatcher = (
     };
   };
 
+/**
+ * Asserts that a value is a record (object) where all values are deeply equal to the expected value.
+ *
+ * @example
+ * expect({ a: 1, b: 1, c: 1 }).toBeRecordOf(1);
+ * expect({ a: 1, b: 1, c: 2 }).not.toBeRecordOf(1);
+ *
+ * expect({ a: 1, b: 2, c: 1 }).toBeRecordOf(expect.any(Number));
+ */
 export const toBeRecordOf = makeRecordOfMatcher("toBeRecordOf", false);
 
+/**
+ * Matches a record (object) where all values are deeply equal to the expected value.
+ *
+ * @example
+ * expect({ value: { a: 1, b: 1, c: 1 } }).toEqual({ value: expect.recordOf(1) });
+ * expect({ value: { a: 1, b: 1, c: 2 } }).not.toEqual({ value: expect.recordOf(1) });
+ *
+ * expect({ value: { a: 1, b: 2, c: 1 } }).toEqual({ value: expect.recordOf(expect.any(Number)) });
+ */
 export const recordOf = makeRecordOfMatcher("recordOf", true);
 
+/**
+ * Asserts that a value is a record (object) where all values are strictly deeply equal to the expected value.
+ *
+ * @example
+ * expect({ a: 1, b: 1, c: 1 }).toBeStrictRecordOf(1);
+ * expect({ a: 1, b: 1, c: 2 }).not.toBeStrictRecordOf(1);
+ *
+ * expect({ a: 1, b: 2, c: 1 }).toBeStrictRecordOf(expect.any(Number));
+ */
 export const toBeStrictRecordOf = makeRecordOfMatcher(
   "toBeStrictRecordOf",
   false,
   true,
 );
 
+/**
+ * Matches a record (object) where all values are strictly deeply equal to the expected value.
+ *
+ * @example
+ * expect({ value: { a: 1, b: 1, c: 1 } }).toEqual({ value: expect.strictRecordOf(1) });
+ * expect({ value: { a: 1, b: 1, c: 2 } }).not.toEqual({ value: expect.strictRecordOf(1) });
+ *
+ * expect({ value: { a: 1, b: 2, c: 1 } }).toEqual({ value: expect.strictRecordOf(expect.any(Number)) });
+ */
 export const strictRecordOf = makeRecordOfMatcher("strictRecordOf", true, true);
 
 declare module "mix-n-matchers" {
   export interface MixNMatchers<R = any, T = unknown> {
+    /**
+     * Asserts that a value is an iterable where all items are deeply equal to the expected value.
+     *
+     * @example
+     * expect([1, 1, 1]).toBeIterableOf(1);
+     * expect([1, 1, 2]).not.toBeIterableOf(1);
+     *
+     * expect([1, 2, 1]).toBeIterableOf(expect.any(Number));
+     */
     toBeIterableOf<E>(expected: E): R;
+    /**
+     * Asserts that a value is an iterable where all items are strictly deeply equal to the expected value.
+     *
+     * @example
+     * expect([1, 1, 1]).toBeStrictIterableOf(1);
+     * expect([1, 1, 2]).not.toBeStrictIterableOf(1);
+     *
+     * expect([1, 2, 1]).toBeStrictIterableOf(expect.any(Number));
+     */
     toBeStrictIterableOf<E>(expected: E): R;
+    /**
+     * Asserts that a value is a record (object) where all values are deeply equal to the expected value.
+     *
+     * @example
+     * expect({ a: 1, b: 1, c: 1 }).toBeRecordOf(1);
+     * expect({ a: 1, b: 1, c: 2 }).not.toBeRecordOf(1);
+     *
+     * expect({ a: 1, b: 2, c: 1 }).toBeRecordOf(expect.any(Number));
+     */
     toBeRecordOf<E>(expected: E): R;
+    /**
+     * Asserts that a value is a record (object) where all values are strictly deeply equal to the expected value.
+     *
+     * @example
+     * expect({ a: 1, b: 1, c: 1 }).toBeStrictRecordOf(1);
+     * expect({ a: 1, b: 1, c: 2 }).not.toBeStrictRecordOf(1);
+     *
+     * expect({ a: 1, b: 2, c: 1 }).toBeStrictRecordOf(expect.any(Number));
+     */
     toBeStrictRecordOf<E>(expected: E): R;
   }
   export interface AsymmetricMixNMatchers {
+    /**
+     * Matches an iterable where all items are deeply equal to the expected value.
+     *
+     * @example
+     * expect({ value: [1, 1, 1] }).toEqual({ value: expect.iterableOf(1) });
+     * expect({ value: [1, 1, 2] }).not.toEqual({ value: expect.iterableOf(1) });
+     *
+     * expect({ value: [1, 2, 1] }).toEqual({ value: expect.iterableOf(expect.any(Number)) });
+     */
     iterableOf<E>(expected: E): any;
+    /**
+     * Matches an iterable where all items are strictly deeply equal to the expected value.
+     *
+     * @example
+     * expect({ value: [1, 1, 1] }).toEqual({ value: expect.strictIterableOf(1) });
+     * expect({ value: [1, 1, 2] }).not.toEqual({ value: expect.strictIterableOf(1) });
+     *
+     * expect({ value: [1, 2, 1] }).toEqual({ value: expect.strictIterableOf(expect.any(Number)) });
+     */
     strictIterableOf<E>(expected: E): any;
+    /**
+     * Matches a record (object) where all values are deeply equal to the expected value.
+     *
+     * @example
+     * expect({ value: { a: 1, b: 1, c: 1 } }).toEqual({ value: expect.recordOf(1) });
+     * expect({ value: { a: 1, b: 1, c: 2 } }).not.toEqual({ value: expect.recordOf(1) });
+     *
+     * expect({ value: { a: 1, b: 2, c: 1 } }).toEqual({ value: expect.recordOf(expect.any(Number)) });
+     */
     recordOf<E>(expected: E): any;
+    /**
+     * Matches a record (object) where all values are strictly deeply equal to the expected value.
+     *
+     * @example
+     * expect({ value: { a: 1, b: 1, c: 1 } }).toEqual({ value: expect.strictRecordOf(1) });
+     * expect({ value: { a: 1, b: 1, c: 2 } }).not.toEqual({ value: expect.strictRecordOf(1) });
+     *
+     * expect({ value: { a: 1, b: 2, c: 1 } }).toEqual({ value: expect.strictRecordOf(expect.any(Number)) });
+     */
     strictRecordOf<E>(expected: E): any;
   }
 }

--- a/src/shared/iterable-of.ts
+++ b/src/shared/iterable-of.ts
@@ -1,0 +1,125 @@
+import type { MatcherFunction } from "../utils/types";
+import { matcherHint, printExpected, printReceived } from "jest-matcher-utils";
+import { isIterable, makeEqualValue } from "../utils";
+
+const makeIterableOfMatcher = (
+  matcherName: string,
+  asymmetric: boolean,
+  strict = false,
+): MatcherFunction<[expected: unknown]> =>
+  function toBeIterableOf(received, expected) {
+    if (!isIterable(received)) {
+      return {
+        pass: false,
+        message: () => `Expected ${printReceived(received)} to be an iterable`,
+      };
+    }
+    const prefix =
+      matcherHint(matcherName, undefined, undefined, {
+        isNot: this.isNot,
+        promise: this.promise,
+        isDirectExpectCall: asymmetric,
+      }) + "\n\n";
+    const equalValue = makeEqualValue(this);
+
+    let i = 0;
+    for (const value of received) {
+      if (!equalValue(value, expected, strict)) {
+        return {
+          pass: false,
+          message: () =>
+            prefix +
+            `Expected ${printReceived(received)} to contain only ${printExpected(expected)} values, but item at index ${i} was ${printReceived(value)}`,
+        };
+      }
+      i++;
+    }
+    return {
+      pass: true,
+      message: () =>
+        prefix +
+        `Expected ${printReceived(received)} not to contain only ${printExpected(expected)} values`,
+    };
+  };
+
+export const toBeIterableOf = makeIterableOfMatcher("toBeIterableOf", false);
+
+export const iterableOf = makeIterableOfMatcher("iterableOf", true);
+
+export const toBeStrictIterableOf = makeIterableOfMatcher(
+  "toBeStrictIterableOf",
+  false,
+  true,
+);
+
+export const strictIterableOf = makeIterableOfMatcher(
+  "strictIterableOf",
+  true,
+  true,
+);
+
+const makeRecordOfMatcher = (
+  matcherName: string,
+  asymmetric: boolean,
+  strict = false,
+): MatcherFunction<[expected: unknown]> =>
+  function toBeRecordOf(received, expected) {
+    if (typeof received !== "object" || received === null) {
+      return {
+        pass: false,
+        message: () =>
+          `Expected ${printReceived(received)} to be an object, but it was ${printReceived(typeof received)}`,
+      };
+    }
+    const prefix =
+      matcherHint(matcherName, undefined, undefined, {
+        isNot: this.isNot,
+        promise: this.promise,
+        isDirectExpectCall: asymmetric,
+      }) + "\n\n";
+    const equalValue = makeEqualValue(this);
+
+    for (const key of Object.keys(received)) {
+      if (!equalValue((received as any)[key], expected, strict)) {
+        return {
+          pass: false,
+          message: () =>
+            prefix +
+            `Expected ${printReceived(received)} to contain only ${printExpected(expected)} values, but item at key ${key} was ${printReceived((received as any)[key])}`,
+        };
+      }
+    }
+    return {
+      pass: true,
+      message: () =>
+        prefix +
+        `Expected ${printReceived(received)} not to contain only ${printExpected(expected)} values`,
+    };
+  };
+
+export const toBeRecordOf = makeRecordOfMatcher("toBeRecordOf", false);
+
+export const recordOf = makeRecordOfMatcher("recordOf", true);
+
+export const toBeStrictRecordOf = makeRecordOfMatcher(
+  "toBeStrictRecordOf",
+  false,
+  true,
+);
+
+export const strictRecordOf = makeRecordOfMatcher("strictRecordOf", true, true);
+
+declare module "mix-n-matchers" {
+  export interface MixNMatchers<R = any, T = unknown> {
+    toBeIterableOf<E>(expected: E): R;
+    toBeStrictIterableOf<E>(expected: E): R;
+    toBeRecordOf<E>(expected: E): R;
+    toBeStrictRecordOf<E>(expected: E): R;
+  }
+  export interface AsymmetricMixNMatchers {
+    iterableOf<E>(expected: E): any;
+    strictIterableOf<E>(expected: E): any;
+    recordOf<E>(expected: E): any;
+    strictRecordOf<E>(expected: E): any;
+  }
+}

--- a/src/shared/iterable-of.ts
+++ b/src/shared/iterable-of.ts
@@ -29,7 +29,7 @@ const makeIterableOfMatcher = (
           pass: false,
           message: () =>
             prefix +
-            `Expected ${printReceived(received)} to contain only ${printExpected(expected)} values, but item at index ${i} was ${printReceived(value)}`,
+            `Expected ${printReceived(received)} to contain only values matching ${printExpected(expected)}, but item at index ${i} was ${printReceived(value)}`,
         };
       }
       i++;
@@ -38,7 +38,7 @@ const makeIterableOfMatcher = (
       pass: true,
       message: () =>
         prefix +
-        `Expected ${printReceived(received)} not to contain only ${printExpected(expected)} values`,
+        `Expected ${printReceived(received)} not to contain only values matching ${printExpected(expected)}`,
     };
   };
 
@@ -121,7 +121,7 @@ const makeRecordOfMatcher = (
           pass: false,
           message: () =>
             prefix +
-            `Expected ${printReceived(received)} to contain only ${printExpected(expected)} values, but item at key ${key} was ${printReceived(value)}`,
+            `Expected ${printReceived(received)} to contain only values matching ${printExpected(expected)}, but item at key ${key} was ${printReceived(value)}`,
         };
       }
     }
@@ -129,7 +129,7 @@ const makeRecordOfMatcher = (
       pass: true,
       message: () =>
         prefix +
-        `Expected ${printReceived(received)} not to contain only ${printExpected(expected)} values`,
+        `Expected ${printReceived(received)} not to contain only values matching ${printExpected(expected)}`,
     };
   };
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -6,9 +6,15 @@ import {
   RECEIVED_COLOR,
   printReceived,
 } from "jest-matcher-utils";
-import type { MatcherUtils } from "./types";
+import type { MatcherUtils, Tester } from "./types";
 import type { Mock } from "vitest";
 import type { jest } from "@jest/globals";
+import {
+  arrayBufferEquality,
+  iterableEquality,
+  sparseArrayEquality,
+  typeEquality,
+} from "@jest/expect-utils";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const isMock = (received: any): received is jest.Mock | Mock =>
@@ -67,10 +73,24 @@ export type EqualValue = (
   strictCheck?: boolean,
 ) => boolean;
 
+export const toStrictEqualTesters: Array<Tester> = [
+  iterableEquality,
+  typeEquality,
+  sparseArrayEquality,
+  arrayBufferEquality,
+];
+
 export const makeEqualValue =
   (utils: MatcherUtils): EqualValue =>
   (a, b, strictCheck) =>
-    utils.equals(a, b, utils.customTesters, strictCheck);
+    utils.equals(
+      a,
+      b,
+      strictCheck
+        ? [...(utils.customTesters ?? []), ...toStrictEqualTesters]
+        : utils.customTesters,
+      strictCheck,
+    );
 
 export const isIterable = (received: unknown): received is Iterable<unknown> =>
   received != null &&

--- a/yarn.lock
+++ b/yarn.lock
@@ -2492,7 +2492,7 @@ glob-parent@^6.0.2:
   dependencies:
     is-glob "^4.0.3"
 
-glob@^10.3.10:
+glob@^10.3.10, glob@^10.3.7:
   version "10.3.10"
   resolved "https://registry.yarnpkg.com/glob/-/glob-10.3.10.tgz#0351ebb809fd187fe421ab96af83d3a70715df4b"
   integrity sha512-fa46+tv1Ak0UPK1TOy/pZrIybNNt4HCv7SDzwyfiOZkvZLEbjsZkJBPtDHVshZjbecAoAGSC20MjLDG/qr679g==
@@ -4119,6 +4119,13 @@ rimraf@^3.0.2:
   integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
   dependencies:
     glob "^7.1.3"
+
+rimraf@^5.0.5:
+  version "5.0.5"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-5.0.5.tgz#9be65d2d6e683447d2e9013da2bf451139a61ccf"
+  integrity sha512-CqDakW+hMe/Bz202FPEymy68P+G50RfMQK+Qo5YUqc9SPipvbGjCGKd0RSKEelbsfQuw3g5NZDSrlZZAJurH1A==
+  dependencies:
+    glob "^10.3.7"
 
 rollup@^4.0.2, rollup@^4.2.0:
   version "4.12.0"


### PR DESCRIPTION
```ts
expect([1, 2, 3]).toBeIterableOf(expect.typeOf("number"));
expect({ a: 1, b: 2 }).toBeRecordOf(expect.typeOf("number"));
expect({ a: 1, b: 2 }).toBeRecordOf(
  expect.oneOf(["a", "b"]),
  expect.typeOf("number"),
);

expect(postEntityState).toEqual({
  ids: expect.iterableOf(expect.any(Number)),
  entities: expect.recordOf({
    id: expect.any(Number),
    title: expect.any(String),
  }),
});
```